### PR TITLE
Put common options in root.go

### DIFF
--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -16,13 +16,14 @@ package pairing
 
 import (
 	"errors"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"net/url"
 	"path"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // pairingCmd represents the pairing command
@@ -38,16 +39,9 @@ var pairingJwt string
 var pairingUrl string
 
 func init() {
-	PairingCmd.PersistentFlags().StringP("realm-key", "k", "",
-		"Path to realm private key used to generate JWT for authentication")
-	PairingCmd.MarkPersistentFlagFilename("realm-key")
-	viper.BindPFlag("realm.key", PairingCmd.PersistentFlags().Lookup("realm-key"))
 	PairingCmd.PersistentFlags().String("pairing-url", "",
 		"Pairing API base URL. Defaults to <astarte-url>/pairing.")
 	viper.BindPFlag("pairing.url", PairingCmd.PersistentFlags().Lookup("pairing-url"))
-	PairingCmd.PersistentFlags().StringP("realm-name", "r", "",
-		"The name of the realm that will be queried")
-	viper.BindPFlag("realm.name", PairingCmd.PersistentFlags().Lookup("realm-name"))
 }
 
 func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -16,13 +16,14 @@ package realm
 
 import (
 	"errors"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"net/url"
 	"path"
 	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // realmManagementCmd represents the realmManagement command
@@ -38,16 +39,9 @@ var realmManagementJwt string
 var realmManagementUrl string
 
 func init() {
-	RealmManagementCmd.PersistentFlags().StringP("realm-key", "k", "",
-		"Path to realm private key used to generate JWT for authentication")
-	RealmManagementCmd.MarkPersistentFlagFilename("realm-key")
-	viper.BindPFlag("realm.key", RealmManagementCmd.PersistentFlags().Lookup("realm-key"))
 	RealmManagementCmd.PersistentFlags().String("realm-management-url", "",
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	viper.BindPFlag("realm-management.url", RealmManagementCmd.PersistentFlags().Lookup("realm-management-url"))
-	RealmManagementCmd.PersistentFlags().StringP("realm-name", "r", "",
-		"The name of the realm that will be queried")
-	viper.BindPFlag("realm.name", RealmManagementCmd.PersistentFlags().Lookup("realm-name"))
 }
 
 func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,11 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.astartectl.yaml)")
 	rootCmd.PersistentFlags().StringP("astarte-url", "u", "", "Base url for your Astarte deployment (e.g. https://api.astarte.example.com)")
 	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("astarte-url"))
+	rootCmd.PersistentFlags().StringP("realm-key", "k", "", "Path to realm private key used to generate JWT for authentication")
+	rootCmd.MarkPersistentFlagFilename("realm-key")
+	viper.BindPFlag("realm.key", rootCmd.PersistentFlags().Lookup("realm-key"))
+	rootCmd.PersistentFlags().StringP("realm-name", "r", "", "The name of the realm that will be queried")
+	viper.BindPFlag("realm.name", rootCmd.PersistentFlags().Lookup("realm-name"))
 
 	rootCmd.AddCommand(housekeeping.HousekeepingCmd)
 	rootCmd.AddCommand(pairing.PairingCmd)


### PR DESCRIPTION
For how the code worked, realm-key was parsed only for Realm Management commands, and Pairing would not parse it (just like any other command). Bringing common options to root.go makes the whole system work again.

Actually, this MR is not enough, as housekeeping sets a "-k" option there, which probably won't work again for the same reason. In general, I think the way Options are handled should be revised a little.