### PR TITLE
Split API calls into a separate, independent API Client

### DIFF
--- a/client/api_types.go
+++ b/client/api_types.go
@@ -1,0 +1,20 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+// Not exported as it's for internal use
+type deviceRegistrationResponse struct {
+	CredentialsSecret string `json:"credentials_secret"`
+}

--- a/client/api_types.go
+++ b/client/api_types.go
@@ -14,7 +14,65 @@
 
 package client
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// ReplicationClass represents different Replication Strategies for a Realm.
+type ReplicationClass int
+
+const (
+	// SimpleStrategy represents a Simple Replication Class, with a single Replication Factor
+	SimpleStrategy ReplicationClass = iota
+	// NetworkTopologyStrategy represents a Replication spread across DataCenters, with individual Replication Factors.
+	NetworkTopologyStrategy
+)
+
+func (s ReplicationClass) String() string {
+	return toString[s]
+}
+
+var toString = map[ReplicationClass]string{
+	SimpleStrategy:          "SimpleStrategy",
+	NetworkTopologyStrategy: "NetworkTopologyStrategy",
+}
+
+var toID = map[string]ReplicationClass{
+	"SimpleStrategy":          SimpleStrategy,
+	"NetworkTopologyStrategy": NetworkTopologyStrategy,
+}
+
+// MarshalJSON marshals the enum as a quoted json string
+func (s ReplicationClass) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(toString[s])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalJSON unmashals a quoted json string to the enum value
+func (s *ReplicationClass) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+	// Note that if the string cannot be found then it will be set to the zero value, 'SimpleStrategy' in this case.
+	*s = toID[j]
+	return nil
+}
+
 // Not exported as it's for internal use
 type deviceRegistrationResponse struct {
 	CredentialsSecret string `json:"credentials_secret"`
+}
+
+// RealmDetails represents details of a single Realm
+type RealmDetails struct {
+	Name                         string           `json:"realm_name"`
+	JwtPublicKeyPEM              string           `json:"jwt_public_key_pem"`
+	ReplicationClass             ReplicationClass `json:"replication_class,omitempty"`
+	ReplicationFactor            int              `json:"replication_factor,omitempty"`
+	DatacenterReplicationFactors map[string]int   `json:"datacenter_replication_factors,omitempty"`
 }

--- a/client/appengine.go
+++ b/client/appengine.go
@@ -1,0 +1,62 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"net/url"
+	"path"
+)
+
+// AppEngineService is the API Client for AppEngine API
+type AppEngineService struct {
+	client       *Client
+	appEngineURL *url.URL
+}
+
+func (s *AppEngineService) ListDevices(realm string, token string) ([]string, error) {
+	callURL, _ := url.Parse(s.appEngineURL.String())
+	callURL.Path = path.Join(callURL.Path, "/v1/"+realm+"/devices")
+	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
+	if err != nil {
+		return nil, err
+	}
+	var responseBody struct {
+		Data []string `json:"data"`
+	}
+	err = decoder.Decode(&responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Data, nil
+}
+
+func (s *AppEngineService) ListDeviceInterfaces(realm string, deviceID string, token string) ([]string, error) {
+	callURL, _ := url.Parse(s.appEngineURL.String())
+	callURL.Path = path.Join(callURL.Path, "/v1/"+realm+"/devices/"+deviceID+"/interfaces")
+	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
+	if err != nil {
+		return nil, err
+	}
+	var responseBody struct {
+		Data []string `json:"data"`
+	}
+	err = decoder.Decode(&responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Data, nil
+}

--- a/client/astarte.go
+++ b/client/astarte.go
@@ -1,0 +1,205 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+)
+
+const (
+	userAgent = "astarte-go"
+)
+
+// Client is the base Astarte API client. It provides access to all of Astarte's APIs.
+type Client struct {
+	baseURL   *url.URL
+	UserAgent string
+
+	httpClient *http.Client
+
+	AppEngine       *AppEngineService
+	Housekeeping    *HousekeepingService
+	Pairing         *PairingService
+	RealmManagement *RealmManagementService
+}
+
+// NewClient creates a new Astarte API client with standard URL hierarchies.
+func NewClient(rawBaseURL string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: time.Second * 30,
+		}
+	}
+
+	baseURL, err := url.Parse(rawBaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{httpClient: httpClient, baseURL: baseURL, UserAgent: userAgent}
+
+	// Apparently that's how you deep-copy the URLs.
+	// We're ignoring errors here as the cross-parsing cannot fail.
+	appEngineURL, _ := url.Parse(baseURL.String())
+	appEngineURL.Path = path.Join(appEngineURL.Path, "appengine")
+	c.AppEngine = &AppEngineService{client: c, appEngineURL: appEngineURL}
+
+	housekeepingURL, _ := url.Parse(baseURL.String())
+	housekeepingURL.Path = path.Join(housekeepingURL.Path, "housekeeping")
+	c.Housekeeping = &HousekeepingService{client: c, housekeepingURL: housekeepingURL}
+
+	pairingURL, _ := url.Parse(baseURL.String())
+	pairingURL.Path = path.Join(pairingURL.Path, "pairing")
+	c.Pairing = &PairingService{client: c, pairingURL: pairingURL}
+
+	realmManagementURL, _ := url.Parse(baseURL.String())
+	realmManagementURL.Path = path.Join(realmManagementURL.Path, "realmmanagement")
+	c.RealmManagement = &RealmManagementService{client: c, realmManagementURL: realmManagementURL}
+
+	return c, nil
+}
+
+// NewClientWithIndividualURLs creates a new Astarte API client with custom URL hierarchies.
+// If an empty string is passed as one of the URLs, the corresponding Service will not be instantiated.
+func NewClientWithIndividualURLs(rawAppEngineURL string, rawHousekeepingURL string, rawPairingURL string,
+	rawRealmManagementURL string, httpClient *http.Client) (*Client, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: time.Second * 30,
+		}
+	}
+
+	c := &Client{httpClient: httpClient, baseURL: nil, UserAgent: userAgent}
+
+	if rawAppEngineURL != "" {
+		appEngineURL, err := url.Parse(rawAppEngineURL)
+		if err != nil {
+			return nil, err
+		}
+		c.AppEngine = &AppEngineService{client: c, appEngineURL: appEngineURL}
+	}
+
+	if rawHousekeepingURL != "" {
+		housekeepingURL, err := url.Parse(rawHousekeepingURL)
+		if err != nil {
+			return nil, err
+		}
+		c.Housekeeping = &HousekeepingService{client: c, housekeepingURL: housekeepingURL}
+	}
+
+	if rawPairingURL != "" {
+		pairingURL, err := url.Parse(rawPairingURL)
+		if err != nil {
+			return nil, err
+		}
+		c.Pairing = &PairingService{client: c, pairingURL: pairingURL}
+	}
+
+	if rawRealmManagementURL != "" {
+		realmManagementURL, err := url.Parse(rawRealmManagementURL)
+		if err != nil {
+			return nil, err
+		}
+		c.RealmManagement = &RealmManagementService{client: c, realmManagementURL: realmManagementURL}
+	}
+
+	return c, nil
+}
+
+func errorFromJSONErrors(responseBody io.Reader) error {
+	var errorBody struct {
+		Errors map[string]interface{} `json:"errors"`
+	}
+
+	err := json.NewDecoder(responseBody).Decode(&errorBody)
+	if err != nil {
+		return err
+	}
+
+	errJSON, _ := json.MarshalIndent(&errorBody, "", "  ")
+	return fmt.Errorf("%s", errJSON)
+}
+
+func (c *Client) genericJSONDataAPIGET(urlString string, authorizationToken string, expectedReturnCode int) (*json.Decoder, error) {
+	req, err := http.NewRequest("GET", urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+authorizationToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != expectedReturnCode {
+		return nil, errorFromJSONErrors(resp.Body)
+	}
+
+	return json.NewDecoder(resp.Body), nil
+}
+
+func (c *Client) genericJSONDataAPIPOST(pathURL string, dataPayload interface{}, authorizationToken string, expectedReturnCode int) error {
+	var requestBody struct {
+		Data interface{} `json:"data"`
+	}
+	requestBody.Data = dataPayload
+
+	b := new(bytes.Buffer)
+	err := json.NewEncoder(b).Encode(requestBody)
+	if err != nil {
+		return err
+	}
+
+	rel := &url.URL{Path: pathURL}
+	u := c.baseURL.ResolveReference(rel)
+
+	req, err := http.NewRequest("POST", u.String(), b)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Authorization", "Bearer "+authorizationToken)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != expectedReturnCode {
+		return errorFromJSONErrors(resp.Body)
+	}
+
+	// When calling this function, we're discarding the response, but there might indeed have been
+	// something in the body. To avoid screwing up our client, we need ensure the response
+	// is drained and the body reader is closed.
+	io.Copy(ioutil.Discard, resp.Body)
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -1,0 +1,23 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "net/url"
+
+// HousekeepingService is the API Client for Housekeeping API
+type HousekeepingService struct {
+	client          *Client
+	housekeepingURL *url.URL
+}

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -47,19 +47,19 @@ func (s *HousekeepingService) ListRealms(token string) ([]string, error) {
 }
 
 // GetRealm returns data about a single Realm.
-func (s *HousekeepingService) GetRealm(realm string, token string) (map[string]interface{}, error) {
+func (s *HousekeepingService) GetRealm(realm string, token string) (RealmDetails, error) {
 	callURL, _ := url.Parse(s.housekeepingURL.String())
 	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/realms/%s", realm))
 	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
 	if err != nil {
-		return nil, err
+		return RealmDetails{}, err
 	}
 	var responseBody struct {
-		Data map[string]interface{} `json:"data"`
+		Data RealmDetails `json:"data"`
 	}
 	err = decoder.Decode(&responseBody)
 	if err != nil {
-		return nil, err
+		return RealmDetails{}, err
 	}
 
 	return responseBody.Data, nil
@@ -98,9 +98,10 @@ func (s *HousekeepingService) createRealmInternal(realm string, publicKeyString 
 	}
 
 	if replicationFactor > 0 {
+		requestBody["replication_class"] = SimpleStrategy.String()
 		requestBody["replication_factor"] = replicationFactor
 	} else if datacenterReplicationFactors != nil {
-		requestBody["replication_class"] = "NetworkTopologyStrategy"
+		requestBody["replication_class"] = NetworkTopologyStrategy.String()
 		requestBody["datacenter_replication_factors"] = datacenterReplicationFactors
 	}
 

--- a/client/housekeeping.go
+++ b/client/housekeeping.go
@@ -14,10 +14,95 @@
 
 package client
 
-import "net/url"
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+)
 
 // HousekeepingService is the API Client for Housekeeping API
 type HousekeepingService struct {
 	client          *Client
 	housekeepingURL *url.URL
+}
+
+// ListRealms returns all realms in the cluster.
+func (s *HousekeepingService) ListRealms(token string) ([]string, error) {
+	callURL, _ := url.Parse(s.housekeepingURL.String())
+	callURL.Path = path.Join(callURL.Path, "/v1/realms")
+	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
+	if err != nil {
+		return nil, err
+	}
+	var responseBody struct {
+		Data []string `json:"data"`
+	}
+	err = decoder.Decode(&responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Data, nil
+}
+
+// GetRealm returns data about a single Realm.
+func (s *HousekeepingService) GetRealm(realm string, token string) (map[string]interface{}, error) {
+	callURL, _ := url.Parse(s.housekeepingURL.String())
+	callURL.Path = path.Join(callURL.Path, fmt.Sprintf("/v1/realms/%s", realm))
+	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
+	if err != nil {
+		return nil, err
+	}
+	var responseBody struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	err = decoder.Decode(&responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Data, nil
+}
+
+// CreateRealm creates a new Realm in the Cluster with default parameters.
+func (s *HousekeepingService) CreateRealm(realm string, publicKeyString string, token string) error {
+	return s.createRealmInternal(realm, publicKeyString, 0, nil, token)
+}
+
+// CreateRealmWithReplicationFactor creates a new Realm in the Cluster with a custom Replication Factor.
+// The replication factor must always be > 0.
+func (s *HousekeepingService) CreateRealmWithReplicationFactor(realm string, publicKeyString string,
+	replicationFactor int, token string) error {
+	if replicationFactor <= 0 {
+		return errors.New("Replication factor should be > 0")
+	}
+	return s.createRealmInternal(realm, publicKeyString, replicationFactor, nil, token)
+}
+
+// CreateRealmWithDatacenterReplication creates a new Realm in the Cluster with a custom,
+// per-datacenter Replication Factor. Both replicationClass and datacenterReplicationFactors must be provided.
+func (s *HousekeepingService) CreateRealmWithDatacenterReplication(realm string, publicKeyString string,
+	datacenterReplicationFactors map[string]int, token string) error {
+	return s.createRealmInternal(realm, publicKeyString, 0, datacenterReplicationFactors, token)
+}
+
+func (s *HousekeepingService) createRealmInternal(realm string, publicKeyString string, replicationFactor int,
+	datacenterReplicationFactors map[string]int, token string) error {
+	callURL, _ := url.Parse(s.housekeepingURL.String())
+	callURL.Path = path.Join(callURL.Path, "/v1/realms")
+
+	requestBody := map[string]interface{}{
+		"realm_name":         realm,
+		"jwt_public_key_pem": publicKeyString,
+	}
+
+	if replicationFactor > 0 {
+		requestBody["replication_factor"] = replicationFactor
+	} else if datacenterReplicationFactors != nil {
+		requestBody["replication_class"] = "NetworkTopologyStrategy"
+		requestBody["datacenter_replication_factors"] = datacenterReplicationFactors
+	}
+
+	return s.client.genericJSONDataAPIPost(callURL.String(), requestBody, token, 201)
 }

--- a/client/pairing.go
+++ b/client/pairing.go
@@ -1,0 +1,23 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "net/url"
+
+// PairingService is the API Client for Pairing API
+type PairingService struct {
+	client     *Client
+	pairingURL *url.URL
+}

--- a/client/realm_management.go
+++ b/client/realm_management.go
@@ -14,10 +14,32 @@
 
 package client
 
-import "net/url"
+import (
+	"net/url"
+	"path"
+)
 
 // RealmManagementService is the API Client for RealmManagement API
 type RealmManagementService struct {
 	client             *Client
 	realmManagementURL *url.URL
+}
+
+// ListInterfaces returns all interfaces in a Realm.
+func (s *RealmManagementService) ListInterfaces(realm string, token string) ([]string, error) {
+	callURL, _ := url.Parse(s.realmManagementURL.String())
+	callURL.Path = path.Join(callURL.Path, "/v1/"+realm+"/interfaces")
+	decoder, err := s.client.genericJSONDataAPIGET(callURL.String(), token, 200)
+	if err != nil {
+		return nil, err
+	}
+	var responseBody struct {
+		Data []string `json:"data"`
+	}
+	err = decoder.Decode(&responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Data, nil
 }

--- a/client/realm_management.go
+++ b/client/realm_management.go
@@ -1,0 +1,23 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "net/url"
+
+// RealmManagementService is the API Client for RealmManagement API
+type RealmManagementService struct {
+	client             *Client
+	realmManagementURL *url.URL
+}

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -16,15 +16,15 @@ package housekeeping
 
 import (
 	"errors"
-	"net/url"
-	"path"
+
+	"github.com/astarte-platform/astartectl/client"
 
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-// housekeepingCmd represents the housekeeping command
+// HousekeepingCmd represents the housekeeping command
 var HousekeepingCmd = &cobra.Command{
 	Use:               "housekeeping",
 	Short:             "Interact with Housekeeping API",
@@ -33,7 +33,7 @@ var HousekeepingCmd = &cobra.Command{
 }
 
 var housekeepingJwt string
-var housekeepingUrl string
+var astarteAPIClient *client.Client
 
 func init() {
 	HousekeepingCmd.PersistentFlags().StringP("housekeeping-key", "k", "",
@@ -46,15 +46,21 @@ func init() {
 }
 
 func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	housekeepingUrlOverride := viper.GetString("housekeeping.url")
-	astarteUrl := viper.GetString("url")
-	if housekeepingUrlOverride != "" {
+	housekeepingURLOverride := viper.GetString("housekeeping.url")
+	astarteURL := viper.GetString("url")
+	if housekeepingURLOverride != "" {
 		// Use explicit housekeeping-url
-		housekeepingUrl = housekeepingUrlOverride
-	} else if astarteUrl != "" {
-		url, _ := url.Parse(astarteUrl)
-		url.Path = path.Join(url.Path, "housekeeping")
-		housekeepingUrl = url.String()
+		var err error
+		astarteAPIClient, err = client.NewClientWithIndividualURLs("", housekeepingURLOverride, "", "", nil)
+		if err != nil {
+			return err
+		}
+	} else if astarteURL != "" {
+		var err error
+		astarteAPIClient, err = client.NewClient(astarteURL, nil)
+		if err != nil {
+			return err
+		}
 	} else {
 		return errors.New("Either astarte-url or housekeeping-url have to be specified")
 	}

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -89,7 +89,6 @@ func realmsListF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println(realms)
@@ -103,7 +102,6 @@ func realmsShowF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Printf("%+v\n", realmDetails)
@@ -163,7 +161,6 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println("ok")

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -15,7 +15,6 @@
 package housekeeping
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -100,15 +99,14 @@ func realmsListF(command *cobra.Command, args []string) error {
 func realmsShowF(command *cobra.Command, args []string) error {
 	realm := args[0]
 
-	realmDefinition, err := astarteAPIClient.Housekeeping.GetRealm(realm, housekeepingJwt)
+	realmDetails, err := astarteAPIClient.Housekeeping.GetRealm(realm, housekeepingJwt)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 		return nil
 	}
 
-	respJSON, _ := json.MarshalIndent(realmDefinition, "", "  ")
-	fmt.Println(string(respJSON))
+	fmt.Printf("%+v\n", realmDetails)
 	return nil
 }
 

--- a/cmd/pairing/agent.go
+++ b/cmd/pairing/agent.go
@@ -15,8 +15,6 @@
 package pairing
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -57,62 +55,25 @@ func init() {
 }
 
 func agentRegisterF(command *cobra.Command, args []string) error {
-	deviceId := args[0]
-	if !utils.IsValidAstarteDeviceID(deviceId) {
+	// TODO: add support for initial_introspection
+	deviceID := args[0]
+	if !utils.IsValidAstarteDeviceID(deviceID) {
 		return errors.New("Invalid device id")
 	}
 
-	// TODO: add support for initial_introspection
-	var requestBody struct {
-		Data struct {
-			HwId string `json:"hw_id"`
-		} `json:"data"`
-	}
-	requestBody.Data.HwId = deviceId
-
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(requestBody)
+	credentialsSecret, err := astarteAPIClient.Pairing.RegisterDevice(realm, deviceID, pairingJwt)
 	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", pairingUrl+"/v1/"+realm+"/agent/devices", b)
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+pairingJwt)
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 201 {
-		var responseBody struct {
-			Data map[string]interface{} `json:"data"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&responseBody)
-		if err != nil {
-			return err
-		}
-
-		respJson, _ := json.MarshalIndent(&responseBody, "", "  ")
-		fmt.Println(string(respJson))
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	// Print the Credentials Secret
+	fmt.Printf("Device %s successfully registered in Realm %s.\n", deviceID, realm)
+	fmt.Printf("The Device's Credentials Secret is \"%s\".\n", credentialsSecret)
+	fmt.Println()
+	fmt.Println("Please don't share the Credentials Secret, and ensure it is transferred securely to your Device.")
+	fmt.Printf("Once the Device pairs for the first time, the Credentials Secret ")
+	fmt.Printf("will be associated permanently to the Device and it won't be changeable anymore.\n")
 	return nil
 }

--- a/cmd/pairing/agent.go
+++ b/cmd/pairing/agent.go
@@ -65,7 +65,6 @@ func agentRegisterF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	// Print the Credentials Secret

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -18,11 +18,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 // interfacesCmd represents the interfaces command
@@ -97,42 +98,14 @@ func init() {
 }
 
 func interfacesListF(command *cobra.Command, args []string) error {
-	req, err := http.NewRequest("GET", realmManagementUrl+"/v1/"+realm+"/interfaces", nil)
+	realmInterfaces, err := astarteAPIClient.RealmManagement.ListInterfaces(realm, realmManagementJwt)
 	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+realmManagementJwt)
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 200 {
-		var responseBody struct {
-			Data []string `json:"data"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&responseBody)
-		if err != nil {
-			return err
-		}
-
-		respJson, _ := json.MarshalIndent(&responseBody, "", "  ")
-		fmt.Println(string(respJson))
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	fmt.Println(realmInterfaces)
 	return nil
 }
 

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -15,13 +15,11 @@
 package realm
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
-	"time"
+	"strconv"
 
 	"github.com/spf13/cobra"
 )
@@ -69,6 +67,18 @@ var interfacesInstallCmd = &cobra.Command{
 	RunE:    interfacesInstallF,
 }
 
+var interfacesDeleteCmd = &cobra.Command{
+	Use:   "delete <interface_name>",
+	Short: "Delete a draft interface",
+	Long: `Deletes the specified interface from the realm.
+Only draft interfaces for which no devices has sent data to can be removed - as such,
+only Major Version 0 of <interface_name> will be deleted, if existing.
+Non-draft interfaces should be removed manually or by your system administrator.`,
+	Example: `  astartectl realm-management interfaces delete com.my.Interface`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    interfacesDeleteF,
+}
+
 var interfacesUpdateCmd = &cobra.Command{
 	Use:   "update <interface_file>",
 	Short: "Update interface",
@@ -81,10 +91,6 @@ The name and major version of the interface are read from the interface file.`,
 	RunE:    interfacesUpdateF,
 }
 
-var netClient = &http.Client{
-	Timeout: time.Second * 30,
-}
-
 func init() {
 	RealmManagementCmd.AddCommand(interfacesCmd)
 
@@ -93,6 +99,7 @@ func init() {
 		interfacesVersionsCmd,
 		interfacesShowCmd,
 		interfacesInstallCmd,
+		interfacesDeleteCmd,
 		interfacesUpdateCmd,
 	)
 }
@@ -111,88 +118,34 @@ func interfacesListF(command *cobra.Command, args []string) error {
 
 func interfacesVersionsF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
-
-	req, err := http.NewRequest("GET", realmManagementUrl+"/v1/"+realm+"/interfaces/"+interfaceName, nil)
+	interfaceVersions, err := astarteAPIClient.RealmManagement.ListInterfaceMajorVersions(realm, interfaceName, realmManagementJwt)
 	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+realmManagementJwt)
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 200 {
-		var responseBody struct {
-			Data []int `json:"data"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&responseBody)
-		if err != nil {
-			return err
-		}
-
-		respJson, _ := json.MarshalIndent(responseBody, "", "  ")
-		fmt.Println(string(respJson))
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	fmt.Println(interfaceVersions)
 	return nil
 }
 
 func interfacesShowF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
-	interfaceMajor := args[1]
-
-	req, err := http.NewRequest("GET", realmManagementUrl+"/v1/"+realm+"/interfaces/"+interfaceName+"/"+interfaceMajor, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+realmManagementJwt)
-
-	resp, err := netClient.Do(req)
+	interfaceMajorString := args[1]
+	interfaceMajor, err := strconv.Atoi(interfaceMajorString)
 	if err != nil {
 		return err
 	}
 
-	if resp.StatusCode == 200 {
-		var responseBody struct {
-			Data map[string]interface{} `json:"data"`
-		}
-
-		err = json.NewDecoder(resp.Body).Decode(&responseBody)
-		if err != nil {
-			return err
-		}
-
-		respJson, _ := json.MarshalIndent(responseBody, "", "  ")
-		fmt.Println(string(respJson))
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+	interfaceDefinition, err := astarteAPIClient.RealmManagement.GetInterface(realm, interfaceName, interfaceMajor, realmManagementJwt)
+	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	respJSON, _ := json.MarshalIndent(interfaceDefinition, "", "  ")
+	fmt.Println(string(respJSON))
 	return nil
 }
 
@@ -208,46 +161,29 @@ func interfacesInstallF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	var requestBody struct {
-		Data map[string]interface{} `json:"data"`
-	}
-	requestBody.Data = interfaceBody
-
-	b := new(bytes.Buffer)
-	err = json.NewEncoder(b).Encode(requestBody)
+	err = astarteAPIClient.RealmManagement.InstallInterface(realm, interfaceBody, realmManagementJwt)
 	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest("POST", realmManagementUrl+"/v1/"+realm+"/interfaces", b)
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+realmManagementJwt)
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 201 {
-		fmt.Println("ok")
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	fmt.Println("ok")
+	return nil
+}
+
+func interfacesDeleteF(command *cobra.Command, args []string) error {
+	interfaceName := args[0]
+	interfaceMajor := 0
+
+	err := astarteAPIClient.RealmManagement.DeleteInterface(realm, interfaceName, interfaceMajor, realmManagementJwt)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+		return nil
+	}
+
+	fmt.Println("ok")
 	return nil
 }
 
@@ -264,47 +200,19 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 	}
 
 	interfaceName := fmt.Sprintf("%v", interfaceBody["interface_name"])
-	interfaceMajor := fmt.Sprintf("%v", interfaceBody["version_major"])
-
-	var requestBody struct {
-		Data map[string]interface{} `json:"data"`
-	}
-	requestBody.Data = interfaceBody
-
-	b := new(bytes.Buffer)
-	err = json.NewEncoder(b).Encode(requestBody)
+	interfaceMajorString := fmt.Sprintf("%v", interfaceBody["version_major"])
+	interfaceMajor, err := strconv.Atoi(interfaceMajorString)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest("PUT", realmManagementUrl+"/v1/"+realm+"/interfaces/"+interfaceName+"/"+interfaceMajor, b)
+	err = astarteAPIClient.RealmManagement.UpdateInterface(realm, interfaceName, interfaceMajor, interfaceBody, realmManagementJwt)
 	if err != nil {
-		return err
-	}
-	req.Header.Add("Authorization", "Bearer "+realmManagementJwt)
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := netClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == 201 {
-		fmt.Println("ok")
-	} else {
-		var errorBody struct {
-			Errors map[string]interface{} `json:"errors"`
-		}
-
-		err = json.NewDecoder(resp.Body).Decode(&errorBody)
-		if err != nil {
-			return err
-		}
-
-		errJson, _ := json.MarshalIndent(&errorBody, "", "  ")
-		fmt.Println(string(errJson))
+		fmt.Println(err)
 		os.Exit(1)
+		return nil
 	}
 
+	fmt.Println("ok")
 	return nil
 }

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -109,7 +109,6 @@ func interfacesListF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println(realmInterfaces)
@@ -122,7 +121,6 @@ func interfacesVersionsF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println(interfaceVersions)
@@ -141,7 +139,6 @@ func interfacesShowF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	respJSON, _ := json.MarshalIndent(interfaceDefinition, "", "  ")
@@ -165,7 +162,6 @@ func interfacesInstallF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println("ok")
@@ -180,7 +176,6 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println("ok")
@@ -210,7 +205,6 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-		return nil
 	}
 
 	fmt.Println("ok")

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -16,8 +16,6 @@ package realm
 
 import (
 	"errors"
-	"net/url"
-	"path"
 
 	"github.com/astarte-platform/astartectl/client"
 
@@ -26,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-// realmManagementCmd represents the realmManagement command
+// RealmManagementCmd represents the realmManagement command
 var RealmManagementCmd = &cobra.Command{
 	Use:               "realm-management",
 	Short:             "Interact with Realm Management API",
@@ -36,7 +34,6 @@ var RealmManagementCmd = &cobra.Command{
 
 var realm string
 var realmManagementJwt string
-var realmManagementUrl string
 var astarteAPIClient *client.Client
 
 func init() {
@@ -51,25 +48,21 @@ func init() {
 }
 
 func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	realmManagementUrlOverride := viper.GetString("realm-management.url")
-	astarteUrl := viper.GetString("url")
-	if realmManagementUrlOverride != "" {
+	realmManagementURLOverride := viper.GetString("realm-management.url")
+	astarteURL := viper.GetString("url")
+	if realmManagementURLOverride != "" {
 		// Use explicit realm-management-url
 		var err error
-		astarteAPIClient, err = client.NewClientWithIndividualURLs("", "", "", realmManagementUrlOverride, nil)
+		astarteAPIClient, err = client.NewClientWithIndividualURLs("", "", "", realmManagementURLOverride, nil)
 		if err != nil {
 			return err
 		}
-		realmManagementUrl = realmManagementUrlOverride
-	} else if astarteUrl != "" {
+	} else if astarteURL != "" {
 		var err error
-		astarteAPIClient, err = client.NewClient(astarteUrl, nil)
+		astarteAPIClient, err = client.NewClient(astarteURL, nil)
 		if err != nil {
 			return err
 		}
-		url, _ := url.Parse(astarteUrl)
-		url.Path = path.Join(url.Path, "realmmanagement")
-		realmManagementUrl = url.String()
 	} else {
 		return errors.New("Either astarte-url or realm-management-url have to be specified")
 	}

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -19,6 +19,8 @@ import (
 	"net/url"
 	"path"
 
+	"github.com/astarte-platform/astartectl/client"
+
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -35,6 +37,7 @@ var RealmManagementCmd = &cobra.Command{
 var realm string
 var realmManagementJwt string
 var realmManagementUrl string
+var astarteAPIClient *client.Client
 
 func init() {
 	RealmManagementCmd.PersistentFlags().StringP("realm-key", "k", "",
@@ -52,8 +55,18 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	astarteUrl := viper.GetString("url")
 	if realmManagementUrlOverride != "" {
 		// Use explicit realm-management-url
+		var err error
+		astarteAPIClient, err = client.NewClientWithIndividualURLs("", "", "", realmManagementUrlOverride, nil)
+		if err != nil {
+			return err
+		}
 		realmManagementUrl = realmManagementUrlOverride
 	} else if astarteUrl != "" {
+		var err error
+		astarteAPIClient, err = client.NewClient(astarteUrl, nil)
+		if err != nil {
+			return err
+		}
 		url, _ := url.Parse(astarteUrl)
 		url.Path = path.Join(url.Path, "realmmanagement")
 		realmManagementUrl = url.String()

--- a/cmd/utils/device_id.go
+++ b/cmd/utils/device_id.go
@@ -98,7 +98,6 @@ func validateDeviceIDF(command *cobra.Command, args []string) error {
 
 	fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
 	os.Exit(1)
-	return nil
 }
 
 func generateRandomDeviceIDF(command *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR creates a new module structure, _client_, which contains a self-sufficient API Client for Astarte APIs, built according to Go best practices.

Currently, all API calls referring to existing commands have been implemented (plus interface deletion in Realm Management).

This PR also contains the full porting of all current commands to the new API client.