### PR TITLE
utils: Use -k as the flag for the token's key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix Datacenter Replication checks in realm creation command
 - Fix a bug that prevented realm key to be set from the command line
 
+### Changed
+- utils gen-jwt accepts the private key through -k rather than through -p, just like all other commands
+
 ## [0.10.0] - 2019-09-20
 ### Added
 - Initial release

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -60,14 +60,14 @@ var genJwtCmd = &cobra.Command{
 	Use:       "gen-jwt <type>",
 	Short:     "Generate a JWT",
 	Long:      `Generate a JWT to access one of astarte APIs.`,
-	Example:   `  astartectl utils gen-jwt realm-management -p test-realm.key`,
+	Example:   `  astartectl utils gen-jwt realm-management -k test-realm.key`,
 	Args:      cobra.ExactArgs(1),
 	ValidArgs: jwtTypes,
 	RunE:      genJwtF,
 }
 
 func init() {
-	genJwtCmd.Flags().StringP("private-key", "p", "", `Path to PEM encoded private key.
+	genJwtCmd.Flags().StringP("private-key", "k", "", `Path to PEM encoded private key.
 Should be Housekeeping key to generate an housekeeping token, Realm key for everything else.`)
 	genJwtCmd.MarkFlagRequired("private-key")
 	genJwtCmd.MarkFlagFilename("private-key")


### PR DESCRIPTION
This brings gen-jwt and token utils in sync with other commands' parameters
