### PR TITLE
token: fix channels default claims

### DIFF
--- a/utils/token.go
+++ b/utils/token.go
@@ -31,7 +31,7 @@ func GenerateAstarteJWTFromPEMKey(privateKeyPEM []byte, astarteService AstarteSe
 	if len(authorizationClaims) == 0 {
 		switch astarteService {
 		case Channels:
-			authorizationClaims = []string{"JOIN::^.*$", "WATCH::^.*$"}
+			authorizationClaims = []string{"JOIN::.*", "WATCH::.*"}
 		default:
 			authorizationClaims = []string{"^.*$::^.*$"}
 		}


### PR DESCRIPTION
Channels don't need explicit regexp delimiting, fix that

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>