### PR TITLE
device_aliases: aliases list accepts exactly 1 argument

### DIFF
--- a/cmd/appengine/device_aliases.go
+++ b/cmd/appengine/device_aliases.go
@@ -35,6 +35,7 @@ var aliasesListCmd = &cobra.Command{
 	Short:   "List aliases",
 	Long:    `List all aliases for a device.`,
 	Example: `  astartectl appengine devices aliases list`,
+	Args:    cobra.ExactArgs(1),
 	RunE:    aliasesListF,
 }
 


### PR DESCRIPTION
Enforce the argument with Cobra