### PR TITLE
appengine: Add an option to skip Realm Management checks, where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.2] - Unreleased
+### Added
+- appengine: Add an option to skip Realm Management checks, where possible
+
 ## [0.10.1] - Unreleased
 ### Added
 - Add commands to generate Device IDs and authentication JWTs


### PR DESCRIPTION
It is not always guaranteed to have access to Realm Management - allow carrying over
requests without having to query Realm Management APIs in Appengine where possible.
