### PR TITLE
Allow using a JWT token rather than passing a Private Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.10.2] - Unreleased
 ### Added
 - appengine: Add an option to skip Realm Management checks, where possible
+- Add possibility to use a token instead of the private key
 
 ## [0.10.1] - Unreleased
 ### Added

--- a/cmd/appengine/appengine.go
+++ b/cmd/appengine/appengine.go
@@ -75,8 +75,9 @@ func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
 	appEngineKey := viper.GetString("realm.key")
-	if appEngineKey == "" {
-		return errors.New("realm-key is required")
+	explicitToken := viper.GetString("token")
+	if appEngineKey == "" && explicitToken == "" {
+		return errors.New("realm-key or token is required")
 	}
 
 	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
@@ -85,14 +86,19 @@ func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("realm is required")
 	}
 
-	var err error
-	appEngineJwt, err = generateAppEngineJWT(appEngineKey)
-	if err != nil {
-		return err
-	}
-	realmManagementJwt, err = generateRealmManagementJWT(appEngineKey)
-	if err != nil {
-		return err
+	if explicitToken == "" {
+		var err error
+		appEngineJwt, err = generateAppEngineJWT(appEngineKey)
+		if err != nil {
+			return err
+		}
+		realmManagementJwt, err = generateRealmManagementJWT(appEngineKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		appEngineJwt = explicitToken
+		realmManagementJwt = explicitToken
 	}
 
 	return nil

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -66,14 +66,19 @@ func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	housekeepingKey := viper.GetString("housekeeping.key")
-	if housekeepingKey == "" {
-		return errors.New("housekeeping-key is required")
+	explicitToken := viper.GetString("token")
+	if housekeepingKey == "" && explicitToken == "" {
+		return errors.New("housekeeping-key or token is required")
 	}
 
-	var err error
-	housekeepingJwt, err = generateHousekeepingJWT(housekeepingKey)
-	if err != nil {
-		return err
+	if explicitToken == "" {
+		var err error
+		housekeepingJwt, err = generateHousekeepingJWT(housekeepingKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		housekeepingJwt = explicitToken
 	}
 
 	return nil

--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -68,8 +68,9 @@ func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
 	pairingKey := viper.GetString("realm.key")
-	if pairingKey == "" {
-		return errors.New("realm-key is required")
+	explicitToken := viper.GetString("token")
+	if pairingKey == "" && explicitToken == "" {
+		return errors.New("realm-key or token is required")
 	}
 
 	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
@@ -78,10 +79,14 @@ func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("realm is required")
 	}
 
-	var err error
-	pairingJwt, err = generatePairingJWT(pairingKey)
-	if err != nil {
-		return err
+	if explicitToken == "" {
+		var err error
+		pairingJwt, err = generatePairingJWT(pairingKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		pairingJwt = explicitToken
 	}
 
 	return nil

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -69,8 +69,9 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 
 	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
 	realmManagementKey := viper.GetString("realm.key")
-	if realmManagementKey == "" {
-		return errors.New("realm-key is required")
+	explicitToken := viper.GetString("token")
+	if realmManagementKey == "" && explicitToken == "" {
+		return errors.New("either realm-key or token is required")
 	}
 
 	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
@@ -79,10 +80,14 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("realm is required")
 	}
 
-	var err error
-	realmManagementJwt, err = generateRealmManagementJWT(realmManagementKey)
-	if err != nil {
-		return err
+	if explicitToken == "" {
+		var err error
+		realmManagementJwt, err = generateRealmManagementJWT(realmManagementKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		realmManagementJwt = explicitToken
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,7 +61,9 @@ func init() {
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.astartectl.yaml)")
 	rootCmd.PersistentFlags().StringP("astarte-url", "u", "", "Base url for your Astarte deployment (e.g. https://api.astarte.example.com)")
+	rootCmd.PersistentFlags().StringP("token", "t", "", "Token for authenticating against Astarte APIs. When set, it takes precedence over any private key setting. Claims in the token have to match the permissions needed for the individual command.")
 	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("astarte-url"))
+	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 
 	rootCmd.AddCommand(housekeeping.HousekeepingCmd)
 	rootCmd.AddCommand(pairing.PairingCmd)


### PR DESCRIPTION
In the real world, users don't have access to the private key of a realm necessarily, but most likely have access to an all-purpose token. This patch allows to provide a token instead of the private key, and use it directly.