### PR TITLE
CHANGELOG.md: Fix wrong entry for 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.4] - Unreleased
+### Added
+- Added the new cluster command, to manage remote, Kubernetes-based, clusters
+
 ## [0.10.3] - 2019-11-06
 ### Added
 - appengine: Aggregates are correctly supported in get-samples
@@ -13,7 +17,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - utils: add command to convert a Device ID to its UUID representation and viceversa
 - Added common aliases for all commands where this is applicable
 - appengine: devices data-snapshot now accepts an additional argument to print the snapshot of a specific interface only
-- Added the new cluster command, to manage remote, Kubernetes-based, clusters
 
 ### Changed
 - "appengine device describe" has been renamed into "appengine device show"


### PR DESCRIPTION
The entry for astartectl cluster was erroneously put under 0.10.3.