### PR TITLE
Implement cluster commands for Profile change and Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fixed Cluster Resource parsing in some corner case situations
 - Do not take into account prereleases when looking for latest versions
+- Added "cluster instance upgrade", to upgrade Astarte instances
+- Added "cluster instance change-profile", to change an existing Astarte instance's deployment profile
 
 ## [0.10.4] - 2019-12-11
 ### Added

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -42,6 +42,7 @@ by installing, upgrading and managing Astarte through its Operator.`,
 	PersistentPreRunE: clusterPersistentPreRunE,
 }
 
+// InstancesCmd represents the instance command
 var InstancesCmd = &cobra.Command{
 	Use:   "instances",
 	Short: "Interact with an Astarte Instance on a remote Astarte Cluster",

--- a/cmd/cluster/deployment/astarte_cluster_profile.go
+++ b/cmd/cluster/deployment/astarte_cluster_profile.go
@@ -53,6 +53,17 @@ type AstarteClusterProfile struct {
 	CustomizableFields []AstarteProfileCustomizableField `yaml:"customizableFields"`
 }
 
+// IsValid returns whether the AstarteClusterProfile is valid or not.
+func (p *AstarteClusterProfile) IsValid() bool {
+	for _, s := range GetAllBuiltinAstarteClusterProfiles() {
+		if s.Name == p.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
 // GetProfilesForVersionAndRequirements gets all profiles compatible with given version and requirements
 func GetProfilesForVersionAndRequirements(version *semver.Version, requirements AstarteProfileRequirements) map[string]AstarteClusterProfile {
 	ret := map[string]AstarteClusterProfile{}
@@ -83,4 +94,28 @@ func GetProfilesForVersionAndRequirements(version *semver.Version, requirements 
 	}
 
 	return ret
+}
+
+// GetMatchingProfile returns a profile which matches name and version requirements, or an invalid profile.
+func GetMatchingProfile(name string, version *semver.Version) AstarteClusterProfile {
+	for _, profile := range GetAllBuiltinAstarteClusterProfiles() {
+		if profile.Name == name {
+			// Check version constraints
+			if profile.Compatibility.MinAstarteVersion != nil {
+				if profile.Compatibility.MinAstarteVersion.GreaterThan(version) {
+					continue
+				}
+			}
+			if profile.Compatibility.MaxAstarteVersion != nil {
+				if profile.Compatibility.MaxAstarteVersion.LessThan(version) {
+					continue
+				}
+			}
+
+			// It's a match!
+			return profile
+		}
+	}
+
+	return AstarteClusterProfile{}
 }

--- a/cmd/cluster/instance_change_profile.go
+++ b/cmd/cluster/instance_change_profile.go
@@ -1,0 +1,175 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/astarte-platform/astartectl/cmd/cluster/deployment"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+)
+
+var instanceChangeProfileCmd = &cobra.Command{
+	Use:   "change-profile <name> [profile]",
+	Short: "Changes the profile of an existing Astarte Instance",
+	Long: `Changes the profile of an existing Astarte Instance in the current Kubernetes Cluster. If profile isn't specified,
+astartectl will prompt the user with a set of available profiles which can be used.`,
+	Example: `  astartectl cluster instances change-profile astarte basic`,
+	RunE:    instanceChangeProfileF,
+	Args:    cobra.RangeArgs(1, 2),
+}
+
+func init() {
+	instanceChangeProfileCmd.PersistentFlags().StringP("namespace", "n", "astarte", "Namespace in which to look for the Astarte resource.")
+	instanceChangeProfileCmd.PersistentFlags().BoolP("non-interactive", "y", false, "Non-interactive mode. Will answer yes by default to all questions.")
+
+	InstancesCmd.AddCommand(instanceChangeProfileCmd)
+}
+
+func instanceChangeProfileF(command *cobra.Command, args []string) error {
+	astartes, err := listAstartes()
+	if err != nil || len(astartes) == 0 {
+		fmt.Println("No Managed Astarte installations found.")
+		return nil
+	}
+
+	resourceName := args[0]
+	resourceNamespace, err := command.Flags().GetString("namespace")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if resourceNamespace == "" {
+		resourceNamespace = "astarte"
+	}
+
+	var astarteObject *unstructured.Unstructured = nil
+	for _, v := range astartes {
+		for _, res := range v.Items {
+			if res.Object["metadata"].(map[string]interface{})["namespace"] == resourceNamespace && res.Object["metadata"].(map[string]interface{})["name"] == resourceName {
+				astarteObject = res.DeepCopy()
+				break
+			}
+		}
+	}
+
+	if astarteObject == nil {
+		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
+		os.Exit(1)
+	}
+
+	astarteSpec := astarteObject.Object["spec"].(map[string]interface{})
+	_, deploymentManager, deploymentProfile := getManagedAstarteResourceStatus(*astarteObject)
+	oldAstarteVersion, err := semver.NewVersion(astarteSpec["version"].(string))
+	if err != nil {
+		fmt.Printf("Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
+		os.Exit(1)
+	}
+
+	if deploymentManager != "astartectl" {
+		fmt.Println("WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
+	}
+
+	newProfile := ""
+	if len(args) == 2 {
+		newProfile = args[1]
+	}
+	astarteDeployment := deployment.AstarteClusterProfile{}
+
+	if deploymentProfile == "" {
+		fmt.Println("Your Astarte instance has no profile associated. I will try to reconcile you with the profile you're going to choose.")
+	} else if newProfile == "" {
+		fmt.Printf("Your Astarte instance is running on '%s'. Let me inspect your cluster to find out if there are any other profiles you can choose from.\n", deploymentProfile)
+	} else if newProfile == deploymentProfile {
+		fmt.Printf("Your Astarte instance is already running on '%s'. All is good!\n", deploymentProfile)
+		os.Exit(0)
+	}
+
+	if newProfile == "" {
+		// Get the profile
+		newProfile, astarteDeployment, err = promptForProfileExcluding(command, oldAstarteVersion, []string{deploymentProfile})
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	} else {
+		// This is much easier. Just match the profile with either its corresponding profile for the next release, or
+		// just ensure that nothing has changed in the profile itself. Should that be the case, we just bump Astarte's version
+		// and call it a day.
+		astarteDeployment = deployment.GetMatchingProfile(newProfile, oldAstarteVersion)
+	}
+
+	newResource := map[string]interface{}{}
+	if astarteDeployment.IsValid() {
+		// Ok. Build it with the standard mechanism.
+		newResource = createAstarteResourceFromExistingSpecOrDie(command, resourceName, resourceNamespace, oldAstarteVersion,
+			newProfile, astarteDeployment, astarteSpec)
+	} else {
+		// Fail.
+		fmt.Printf("I found no matching '%s' profile for Astarte %s. Maybe you spelled the profile wrong, or you should upgrade astartectl first?\n", newProfile, oldAstarteVersion)
+		os.Exit(1)
+	}
+
+	// Time for some Kubernetes dark magic
+	preconditions := []mergepatch.PreconditionFunc{mergepatch.RequireMetadataKeyUnchanged("namespace"), mergepatch.RequireMetadataKeyUnchanged("name")}
+	oldResourceJSON, err := runtimeObjectToJSON(astarteObject)
+	newResourceJSON, err := json.Marshal(newResource)
+
+	// To build the original resource, kill the status field, and replace all metadata with the new metadata.
+	originalResourceBytes, err := runtimeObjectToJSON(astarteObject)
+	originalResourceJSON := map[string]interface{}{}
+	json.Unmarshal(originalResourceBytes, &originalResourceJSON)
+	delete(originalResourceJSON, "status")
+	delete(originalResourceJSON, "metadata")
+	originalResourceJSON["metadata"] = newResource["metadata"]
+	originalResourceBytes, err = json.Marshal(originalResourceJSON)
+
+	// Build the patch
+	patch, err := jsonmergepatch.CreateThreeWayJSONMergePatch(originalResourceBytes, newResourceJSON, oldResourceJSON,
+		preconditions...)
+
+	review, err := utils.AskForConfirmation("Ready to change profile! Would you like to review the patch?")
+	if review {
+		fmt.Println(string(patch))
+	}
+	goAhead, err := utils.AskForConfirmation(fmt.Sprintf("Your Astarte instance profile will be switched from '%v' to '%v'. Would you like to continue?",
+		deploymentProfile, newProfile))
+	if !goAhead {
+		fmt.Println("Oh, okay :(")
+		os.Exit(0)
+	}
+
+	fmt.Println("Ok. Hold on a second while I change your Astarte profile...")
+
+	_, err = kubernetesDynamicClient.Resource(astarteV1Alpha1).Namespace(resourceNamespace).Patch(
+		resourceName, types.MergePatchType, patch, v1.PatchOptions{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Done! Astarte Operator will take over from here. Watch your cluster and monitor your resources to ensure the profile change was successful.")
+
+	return nil
+}

--- a/cmd/cluster/instance_upgrade.go
+++ b/cmd/cluster/instance_upgrade.go
@@ -1,0 +1,209 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/astarte-platform/astartectl/cmd/cluster/deployment"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+)
+
+var instanceUpgradeCmd = &cobra.Command{
+	Use:     "upgrade <name> <version>",
+	Short:   "Shows details about an Astarte Instance in the current Kubernetes Cluster",
+	Long:    `Shows details about an Astarte Instance in the current Kubernetes Cluster.`,
+	Example: `  astartectl cluster instances upgrade astarte 0.10.2`,
+	RunE:    instanceUpgradeF,
+	Args:    cobra.RangeArgs(1, 2),
+}
+
+func init() {
+	instanceUpgradeCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
+	instanceUpgradeCmd.PersistentFlags().String("profile", "", "Astarte Deployment Profile. Ignored if the existing Astarte instance is already associated to a Profile. If not specified and not associated yet, it will be prompted when deploying.")
+	instanceUpgradeCmd.PersistentFlags().BoolP("non-interactive", "y", false, "Non-interactive mode. Will answer yes by default to all questions.")
+
+	InstancesCmd.AddCommand(instanceUpgradeCmd)
+}
+
+func instanceUpgradeF(command *cobra.Command, args []string) error {
+	astartes, err := listAstartes()
+	if err != nil || len(astartes) == 0 {
+		fmt.Println("No Managed Astarte installations found.")
+		return nil
+	}
+
+	resourceName := args[0]
+	resourceNamespace, err := command.Flags().GetString("namespace")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if resourceNamespace == "" {
+		resourceNamespace = "astarte"
+	}
+
+	var astarteObject *unstructured.Unstructured = nil
+	for _, v := range astartes {
+		for _, res := range v.Items {
+			if res.Object["metadata"].(map[string]interface{})["namespace"] == resourceNamespace && res.Object["metadata"].(map[string]interface{})["name"] == resourceName {
+				astarteObject = res.DeepCopy()
+				break
+			}
+		}
+	}
+
+	if astarteObject == nil {
+		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
+		os.Exit(1)
+	}
+
+	astarteSpec := astarteObject.Object["spec"].(map[string]interface{})
+	_, deploymentManager, deploymentProfile := getManagedAstarteResourceStatus(*astarteObject)
+	oldAstarteVersion, err := semver.NewVersion(astarteSpec["version"].(string))
+	if err != nil {
+		fmt.Printf("Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
+		os.Exit(1)
+	}
+
+	if deploymentManager != "astartectl" {
+		fmt.Println("WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
+	}
+
+	// Good. Let's check the version now.
+	version := ""
+	if len(args) == 2 {
+		version = args[1]
+	}
+	if version == "" {
+		latestAstarteVersion, _ := getLastAstarteRelease()
+		latestAstarteSemVersion, err := semver.NewVersion(latestAstarteVersion)
+		if latestAstarteSemVersion.Compare(oldAstarteVersion) < 1 {
+			fmt.Printf("Latest released Astarte version is %s. You're on latest and greatest!\n", latestAstarteVersion)
+			os.Exit(0)
+		}
+		version, err = utils.PromptChoice("What Astarte version would you like to upgrade to?", latestAstarteVersion, false)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+	astarteVersion, err := semver.NewVersion(version)
+	if err != nil {
+		fmt.Printf("%s is not a valid Astarte version", version)
+		os.Exit(1)
+	}
+
+	if astarteVersion.Compare(oldAstarteVersion) < 1 {
+		fmt.Printf("Your Astarte cluster is running Astarte %s, no need for upgrades today.", version)
+		os.Exit(0)
+	}
+
+	astarteDeployment := deployment.AstarteClusterProfile{}
+
+	if deploymentProfile == "" {
+		fmt.Println("It looks like this deployment has no profile associated. To move forward, you should probably associate a profile. You may choose not to, but in that case, I won't be able to help you if anything changed in the Operator.")
+		associateProfile, err := utils.AskForConfirmation("Would you like to associate a profile?")
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		if associateProfile {
+			fmt.Println("Whew, good choice. Let me inspect your cluster and tell you what's available. Then, I'll do my best to ask you only for what's strictly needed:")
+			fmt.Println()
+
+			// Get the profile
+			deploymentProfile, astarteDeployment, err = promptForProfile(command, astarteVersion)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		} else {
+			fmt.Println("Ok, I'll just try and upgrade blindly. Don't say I didn't warn you!")
+		}
+	} else {
+		// This is much easier. Just match the profile with either its corresponding profile for the next release, or
+		// just ensure that nothing has changed in the profile itself. Should that be the case, we just bump Astarte's version
+		// and call it a day.
+		astarteDeployment = deployment.GetMatchingProfile(deploymentProfile, astarteVersion)
+		if !astarteDeployment.IsValid() {
+			fmt.Printf("I found no matching '%s' profile for Astarte %s. Maybe upgrade astartectl?\n", deploymentProfile, version)
+			os.Exit(1)
+		}
+		fmt.Println("Found a matching profile. Let me handle the hard stuff for you then, you're in good hands!")
+	}
+
+	newResource := map[string]interface{}{}
+	if astarteDeployment.IsValid() {
+		// Ok. Build it with the standard mechanism.
+		newResource = createAstarteResourceFromExistingSpecOrDie(command, resourceName, resourceNamespace, astarteVersion,
+			deploymentProfile, astarteDeployment, astarteSpec)
+	} else {
+		// Patch the hell out of the existing resource, and hope for the best.
+		newResource = astarteObject.DeepCopy().Object
+		newResource["spec"].(map[string]interface{})["version"] = version
+	}
+
+	// Time for some Kubernetes dark magic
+	preconditions := []mergepatch.PreconditionFunc{mergepatch.RequireMetadataKeyUnchanged("namespace"), mergepatch.RequireMetadataKeyUnchanged("name")}
+	oldResourceJSON, err := runtimeObjectToJSON(astarteObject)
+	newResourceJSON, err := json.Marshal(newResource)
+
+	// To build the original resource, kill the status field, and replace all metadata with the new metadata.
+	originalResourceBytes, err := runtimeObjectToJSON(astarteObject)
+	originalResourceJSON := map[string]interface{}{}
+	json.Unmarshal(originalResourceBytes, &originalResourceJSON)
+	delete(originalResourceJSON, "status")
+	delete(originalResourceJSON, "metadata")
+	originalResourceJSON["metadata"] = newResource["metadata"]
+	originalResourceBytes, err = json.Marshal(originalResourceJSON)
+
+	// Build the patch
+	patch, err := jsonmergepatch.CreateThreeWayJSONMergePatch(originalResourceBytes, newResourceJSON, oldResourceJSON,
+		preconditions...)
+
+	review, err := utils.AskForConfirmation("Ready to upgrade! Would you like to review the patch?")
+	if review {
+		fmt.Println(string(patch))
+	}
+	goAhead, err := utils.AskForConfirmation(fmt.Sprintf("Your cluster will be upgraded from version %v to version %v. Would you like to continue?",
+		oldAstarteVersion.Original(), version))
+	if !goAhead {
+		fmt.Println("Oh, okay :(")
+		os.Exit(0)
+	}
+
+	fmt.Println("Ok. Hold on a second while I upgrade Astarte...")
+
+	_, err = kubernetesDynamicClient.Resource(astarteV1Alpha1).Namespace(resourceNamespace).Patch(
+		resourceName, types.MergePatchType, patch, v1.PatchOptions{})
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Done! Astarte Operator will take over from here. Watch your cluster and monitor your resources to ensure the upgrade was successful.")
+
+	return nil
+}

--- a/cmd/cluster/profile_helpers.go
+++ b/cmd/cluster/profile_helpers.go
@@ -1,0 +1,132 @@
+// Copyright © 2019 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"fmt"
+	"go/types"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/astarte-platform/astartectl/cmd/cluster/deployment"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+func createAstarteResourceFromExistingSpecOrDie(command *cobra.Command, resourceName, resourceNamespace string, astarteVersion *semver.Version, profileName string, astarteDeployment deployment.AstarteClusterProfile, spec map[string]interface{}) map[string]interface{} {
+	// Let's go
+	astarteDeployment.DefaultSpec.Version = astarteVersion.String()
+	astarteDeployment.DefaultSpec.API.Host = getStringFromSpecOrFlagOrPromptOrDie(spec, "api.host", command, "api-host", "Please enter the API Host for this Deployment:", "", false)
+	astarteDeployment.DefaultSpec.Vernemq.Host = getStringFromSpecOrFlagOrPromptOrDie(spec, "vernemq.host", command, "broker-host", "Please enter the MQTT Broker Host for this Deployment:", "", false)
+	storageClass := getStringFromSpecOrFlag(spec, "storageClassName", command, "storage-class-name")
+	if storageClass != "" {
+		astarteDeployment.DefaultSpec.StorageClassName = getStringFromSpecOrFlag(spec, "storageClassName", command, "storage-class-name")
+	}
+
+	// Ensure Storage and dependencies for all components.
+	if astarteDeployment.DefaultSpec.Cassandra.Deploy {
+		astarteDeployment.DefaultSpec.Cassandra.Storage.Size = getStringFromSpecOrFlagOrPromptOrDie(spec, "cassandra.storage.size", command, "cassandra-volume-size", "Please enter the Cassandra Volume size for this Deployment:",
+			astarteDeployment.DefaultSpec.Cassandra.Storage.Size, false)
+	} else {
+		// Ask for nodes
+		astarteDeployment.DefaultSpec.Cassandra.Nodes = getStringFromSpecOrFlagOrPromptOrDie(spec, "cassandra.nodes", command, "cassandra-nodes", "Please enter a comma separated list of Cassandra Nodes the cluster will connect to:",
+			astarteDeployment.DefaultSpec.Cassandra.Nodes, false)
+	}
+	if astarteDeployment.DefaultSpec.Rabbitmq.Deploy {
+		astarteDeployment.DefaultSpec.Rabbitmq.Storage.Size = getStringFromSpecOrFlagOrPromptOrDie(spec, "rabbitmq.storage.size", command, "rabbitmq-volume-size", "Please enter the RabbitMQ Volume size for this Deployment:",
+			astarteDeployment.DefaultSpec.Rabbitmq.Storage.Size, false)
+	}
+	if astarteDeployment.DefaultSpec.Vernemq.Deploy {
+		astarteDeployment.DefaultSpec.Vernemq.Storage.Size = getStringFromSpecOrFlagOrPromptOrDie(spec, "vernemq.storage.size", command, "vernemq-volume-size", "Please enter the VerneMQ Volume size for this Deployment:",
+			astarteDeployment.DefaultSpec.Vernemq.Storage.Size, false)
+	}
+	if astarteDeployment.DefaultSpec.Cfssl.Deploy {
+		astarteDeployment.DefaultSpec.Cfssl.Storage.Size = getStringFromSpecOrFlagOrPromptOrDie(spec, "cfssl.storage.size", command, "cfssl-volume-size", "Please enter the CFSSL Volume size for this Deployment:",
+			astarteDeployment.DefaultSpec.Cfssl.Storage.Size, false)
+		cfsslDBDriver := getStringFromSpecOrFlagOrPromptOrDie(spec, "cfssl.dbConfig.driver", command, "cfssl-db-driver", "Please enter the CFSSL DB Driver for this deployment.\nPlease note that leaving this empty will default to using SQLite, which is strongly discouraged in production.\nCFSSL DB Driver:",
+			"", true)
+		if cfsslDBDriver != "" && cfsslDBDriver != "sqlite3" {
+			fmt.Println(cfsslDBDriver)
+			astarteDeployment.DefaultSpec.Cfssl.DbConfig.Driver = cfsslDBDriver
+			astarteDeployment.DefaultSpec.Cfssl.DbConfig.DataSource = getStringFromSpecOrFlagOrPromptOrDie(spec, "cfssl.dbConfig.dataSource", command, "cfssl-db-datasource", "Please enter the CFSSL DB Datasource (Connection URL) for this Deployment:",
+				"", false)
+		}
+	}
+
+	customFields := map[string]interface{}{}
+	// Now we go with the custom fields
+	for _, customizableField := range astarteDeployment.CustomizableFields {
+		stringValue := getFromSpecOrPromptOrDie(spec, customizableField.Field, command, customizableField.Question,
+			fmt.Sprintf("%v", customizableField.Default), customizableField.AllowEmpty)
+		switch customizableField.Type {
+		case types.Int:
+			i, err := strconv.Atoi(stringValue)
+			if err != nil {
+				fmt.Printf("%v is not a valid value for %v.\n", stringValue, customizableField.Field)
+				os.Exit(1)
+			}
+			customFields[customizableField.Field] = i
+		case types.Bool:
+			b, err := strconv.ParseBool(stringValue)
+			if err != nil {
+				fmt.Printf("%v is not a valid value for %v.\n", stringValue, customizableField.Field)
+				os.Exit(1)
+			}
+			customFields[customizableField.Field] = b
+		default:
+			customFields[customizableField.Field] = stringValue
+		}
+	}
+
+	// Assemble the Astarte resource
+	astarteK8sDeployment := deployment.GetBaseAstartev1alpha1Deployment()
+	astarteK8sDeployment.Metadata.Name = resourceName
+	astarteK8sDeployment.Metadata.Namespace = resourceNamespace
+	astartectlAnnotations := map[string]string{
+		"astarte-platform.org/deployment-manager": "astartectl",
+		"astarte-platform.org/deployment-profile": profileName,
+	}
+	astarteK8sDeployment.Metadata.Annotations = astartectlAnnotations
+	astarteK8sDeployment.Spec = astarteDeployment.DefaultSpec
+
+	astarteDeploymentYaml, err := yaml.Marshal(astarteK8sDeployment)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	astarteDeploymentResource, err := utils.UnmarshalYAMLToJSON(astarteDeploymentYaml)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	// Go with the custom fields
+	for customField, customFieldValue := range customFields {
+		fieldTokens := strings.Split(customField, ".")
+		astarteDeploymentResource["spec"] = setInMapRecursively(astarteDeploymentResource["spec"].(map[string]interface{}),
+			fieldTokens, customFieldValue)
+	}
+
+	return astarteDeploymentResource
+}
+
+func createAstarteResourceOrDie(command *cobra.Command, astarteVersion *semver.Version, profileName string, astarteDeployment deployment.AstarteClusterProfile) map[string]interface{} {
+	resourceName := getStringFlagFromPromptOrDie(command, "name", "Please enter the name for this Astarte instance:", "astarte", false)
+	resourceNamespace := getStringFlagFromPromptOrDie(command, "namespace", "Please enter the namespace where the Astarte instance will be deployed:", "astarte", false)
+	// Reconciling with an empty spec will bear the very same effect
+	return createAstarteResourceFromExistingSpecOrDie(command, resourceName, resourceNamespace, astarteVersion, profileName, astarteDeployment, map[string]interface{}{})
+}


### PR DESCRIPTION
This PR adds support in `cluster` to instance upgrades and profile changes. It uses a custom logic to reconcile profiles with existing Kubernetes resources, and 3-way JSON merge patch to reconcile resources on Kubernetes (much like kubectl apply does).