### PR TITLE
cluster: Fix getClusterAllocatableResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed Cluster Resource parsing in some corner case situations
 
 ## [0.10.4] - 2019-12-11
 ### Added


### PR DESCRIPTION
Use the right functions and hooks to always get milliCPUs and Memory Bytes.