### PR TITLE
Skip prereleases when looking for latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Fixed Cluster Resource parsing in some corner case situations
+- Do not take into account prereleases when looking for latest versions
 
 ## [0.10.4] - 2019-12-11
 ### Added

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -127,6 +127,9 @@ func getLastReleaseForAstarteRepo(repo string) (string, error) {
 		if err != nil {
 			continue
 		}
+		if ver.Prerelease() != "" {
+			continue
+		}
 
 		collection = append(collection, ver)
 	}


### PR DESCRIPTION
We definitely do not want users to update or install a Beta without any explicit
request.