### PR TITLE
Fix all issues with 0.11 Operator and snapshot

### DIFF
--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -148,8 +148,14 @@ func getContentFromAstarteRepo(repo string, path string, tag string) (string, er
 	ctx := context.Background()
 	client := github.NewClient(nil)
 
+	ref := "v" + tag
+	if strings.Contains(tag, "-snapshot") {
+		// In this case, we want to fetch from the latest release branch.
+		ref = "release-" + strings.Replace(tag, "-snapshot", "", -1)
+	}
+
 	content, _, _, err := client.Repositories.GetContents(ctx, "astarte-platform", repo,
-		path, &github.RepositoryContentGetOptions{Ref: "v" + tag})
+		path, &github.RepositoryContentGetOptions{Ref: ref})
 
 	if err != nil {
 		return "", nil


### PR DESCRIPTION
This PR makes astartectl cluster fully functional with all the new goodies in 0.11, and most of all fixes snapshot behavior.