### PR TITLE
Fix Aggregate management in appengine devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0-rc.1] - Unreleased
 ### Changed
 - Moved the codebase to use astarte-go instead of the internal replicated tree
+- `appengine devices get-samples` now handles aggregates with an explicit invocation rather than guessing
+  it from the path
 
 ## [0.11.0-rc.0] - 2020-02-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.0-rc.1] - Unreleased
+### Fixed
+- appengine: Fix crash when retrieving nil values out of device interfaces
+
 ### Changed
 - Moved the codebase to use astarte-go instead of the internal replicated tree
 - `appengine devices get-samples` now handles aggregates with an explicit invocation rather than guessing

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -356,6 +356,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 						} else {
 							for _, k := range aggregate.Values.Keys() {
 								v, _ := aggregate.Values.Get(k)
+								if v == nil {
+									v = "(null)"
+								}
 								t.AppendRow([]interface{}{snapshotInterface, fmt.Sprintf("%s/%s", path, k), v, timestampForOutput(aggregate.Timestamp, outputType)})
 							}
 						}
@@ -370,6 +373,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 					} else {
 						for _, k := range val.Values.Keys() {
 							v, _ := val.Values.Get(k)
+							if v == nil {
+								v = "(null)"
+							}
 							t.AppendRow([]interface{}{snapshotInterface, fmt.Sprintf("/%s", k), v, timestampForOutput(val.Timestamp, outputType)})
 						}
 					}
@@ -382,6 +388,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 				jsonRepresentation := make(map[string]interface{})
 				for k, v := range val {
 					jsonRepresentation[k] = v
+					if v.Value == nil {
+						v.Value = "(null)"
+					}
 					t.AppendRow([]interface{}{snapshotInterface, k, v.Value, timestampForOutput(v.Timestamp, outputType)})
 				}
 				jsonOutput[snapshotInterface] = jsonRepresentation
@@ -395,6 +404,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 			jsonRepresentation := make(map[string]interface{})
 			for k, v := range val {
 				jsonRepresentation[k] = v
+				if v == nil {
+					v = "(null)"
+				}
 				t.AppendRow([]interface{}{snapshotInterface, k, v})
 			}
 			jsonOutput[snapshotInterface] = jsonRepresentation
@@ -428,6 +440,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 							} else {
 								for _, k := range aggregate.Values.Keys() {
 									v, _ := aggregate.Values.Get(k)
+									if v == nil {
+										v = "(null)"
+									}
 									t.AppendRow([]interface{}{astarteInterface, fmt.Sprintf("%s/%s", path, k), v, interfaceDescription.Ownership.String(),
 										timestampForOutput(aggregate.Timestamp, outputType)})
 								}
@@ -443,6 +458,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 						} else {
 							for _, k := range val.Values.Keys() {
 								v, _ := val.Values.Get(k)
+								if v == nil {
+									v = "(null)"
+								}
 								t.AppendRow([]interface{}{astarteInterface, fmt.Sprintf("/%s", k), v, interfaceDescription.Ownership.String(),
 									timestampForOutput(val.Timestamp, outputType)})
 							}
@@ -456,6 +474,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 					jsonRepresentation := make(map[string]interface{})
 					for k, v := range val {
 						jsonRepresentation[k] = v
+						if v.Value == nil {
+							v.Value = "(null)"
+						}
 						t.AppendRow([]interface{}{astarteInterface, k, v.Value, interfaceDescription.Ownership.String(),
 							timestampForOutput(v.Timestamp, outputType)})
 					}
@@ -469,6 +490,9 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 				jsonRepresentation := make(map[string]interface{})
 				for k, v := range val {
 					jsonRepresentation[k] = v
+					if v == nil {
+						v = "(null)"
+					}
 					t.AppendRow([]interface{}{astarteInterface, k, v, interfaceDescription.Ownership.String(), ""})
 				}
 				jsonOutput[astarteInterface] = jsonRepresentation
@@ -663,7 +687,11 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 						if !headerPrinted {
 							headerRow = append(headerRow, path)
 						}
-						line = append(line, value)
+						if value != nil {
+							line = append(line, value)
+						} else {
+							line = append(line, "(null)")
+						}
 					}
 					if !headerPrinted {
 						t.AppendHeader(headerRow)


### PR DESCRIPTION
This PR fixes both a poor user experience when dealing with astartectl and aggregates (now `appengine devices get-samples` does no longer require `path` to be specified when dealing with an aggregate), and a panic whenever an aggregate reported missing endpoints.