### PR TITLE
Fix panic in appengine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0-rc.1] - Unreleased
 ### Fixed
 - appengine: Fix crash when retrieving nil values out of device interfaces
+- appengine: Fix panic when passing appengine-url without realmmanagement-url (#73)
 
 ### Changed
 - Moved the codebase to use astarte-go instead of the internal replicated tree

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -250,15 +250,16 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	skipRealmManagementChecks = skipRealmManagementChecks || astarteAPIClient.RealmManagement == nil
 	if skipRealmManagementChecks && snapshotInterface == "" {
-		return fmt.Errorf("When using --skip-realm-management-checks, an interface should always be specified")
+		return fmt.Errorf("When not using Realm Management checks, an interface should always be specified")
 	}
 	interfaceTypeString, err := command.Flags().GetString("interface-type")
 	if err != nil {
 		return err
 	}
 	if skipRealmManagementChecks && interfaceTypeString == "" {
-		return fmt.Errorf("When using --skip-realm-management-checks, --interface-type should always be specified")
+		return fmt.Errorf("When not using Realm Management checks, --interface-type should always be specified")
 	}
 
 	outputType, err := command.Flags().GetString("output")
@@ -537,6 +538,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	skipRealmManagementChecks = skipRealmManagementChecks || astarteAPIClient.RealmManagement == nil
 	forceAggregate, err := command.Flags().GetBool("aggregate")
 	if err != nil {
 		return err

--- a/utils/client.go
+++ b/utils/client.go
@@ -33,7 +33,7 @@ func APICommandSetup(individualURLVariables map[misc.AstarteService]string, keyV
 	for k, v := range individualURLVariables {
 		urlOverride := viper.GetString(v)
 		if urlOverride != "" {
-			individualURLVariables[k] = urlOverride
+			individualURLs[k] = urlOverride
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #73 , and also fixes a regression introduced in the astarte-go porting due to a typo.