### PR TITLE
Port astartectl to use new context-based config

### DIFF
--- a/cmd/appengine/appengine.go
+++ b/cmd/appengine/appengine.go
@@ -43,7 +43,7 @@ func init() {
 	AppEngineCmd.MarkPersistentFlagFilename("realm-key")
 	AppEngineCmd.PersistentFlags().String("appengine-url", "",
 		"AppEngine API base URL. Defaults to <astarte-url>/appengine.")
-	viper.BindPFlag("appengine.url", AppEngineCmd.PersistentFlags().Lookup("appengine-url"))
+	viper.BindPFlag("individual-urls.appengine", AppEngineCmd.PersistentFlags().Lookup("appengine-url"))
 	AppEngineCmd.PersistentFlags().String("realm-management-url", "",
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	AppEngineCmd.PersistentFlags().StringP("realm-name", "r", "",
@@ -51,22 +51,22 @@ func init() {
 }
 
 func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
-	appEngineURLOverride := viper.GetString("appengine.url")
-	viper.BindPFlag("realm-management.url", cmd.Flags().Lookup("realm-management-url"))
-	realmManagementURLOverride := viper.GetString("realm-management.url")
+	appEngineURLOverride := viper.GetString("individual-urls.appengine")
+	viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
+	realmManagementURLOverride := viper.GetString("individual-urls.realm-management")
 	// Handle a special failure case, if realm-management is provided but appengine isn't
 	if appEngineURLOverride == "" && realmManagementURLOverride != "" {
 		return errors.New("Either astarte-url or appengine-url have to be specified")
 	}
 
 	individualURLVariables := map[misc.AstarteService]string{
-		misc.AppEngine:       "appengine.url",
-		misc.RealmManagement: "realm-management.url",
+		misc.AppEngine:       "individual-urls.appengine",
+		misc.RealmManagement: "individual-urls.realm-management",
 	}
 
-	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
+	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
-	astarteAPIClient, err = utils.APICommandSetup(individualURLVariables, "realm.key")
+	astarteAPIClient, err = utils.APICommandSetup(individualURLVariables, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -37,15 +37,16 @@ func init() {
 	HousekeepingCmd.PersistentFlags().StringP("housekeeping-key", "k", "",
 		"Path to housekeeping private key to generate JWT for authentication")
 	HousekeepingCmd.MarkPersistentFlagFilename("housekeeping-key")
-	viper.BindPFlag("housekeeping.key", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-key"))
+	viper.BindPFlag("housekeeping.key-file", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-key"))
 	HousekeepingCmd.PersistentFlags().String("housekeeping-url", "",
 		"Housekeeping API base URL. Defaults to <astarte-url>/housekeeping.")
-	viper.BindPFlag("housekeeping.url", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-url"))
+	viper.BindPFlag("individual-urls.housekeeping", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-url"))
 }
 
 func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	var err error
-	astarteAPIClient, err = utils.APICommandSetup(map[misc.AstarteService]string{misc.Housekeeping: "housekeeping.url"}, "housekeeping.key")
+	astarteAPIClient, err = utils.APICommandSetup(map[misc.AstarteService]string{misc.Housekeeping: "individual-urls.housekeeping"},
+		"housekeeping.key", "housekeeping.key-file")
 
 	return err
 }

--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -41,15 +41,16 @@ func init() {
 	PairingCmd.MarkPersistentFlagFilename("realm-key")
 	PairingCmd.PersistentFlags().String("pairing-url", "",
 		"Pairing API base URL. Defaults to <astarte-url>/pairing.")
-	viper.BindPFlag("pairing.url", PairingCmd.PersistentFlags().Lookup("pairing-url"))
+	viper.BindPFlag("individual-urls.pairing", PairingCmd.PersistentFlags().Lookup("pairing-url"))
 	PairingCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
 }
 
 func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
+	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
-	astarteAPIClient, err = utils.APICommandSetup(map[misc.AstarteService]string{misc.Pairing: "pairing.url"}, "realm.key")
+	astarteAPIClient, err = utils.APICommandSetup(
+		map[misc.AstarteService]string{misc.Pairing: "individual-urls.pairing"}, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -47,11 +47,11 @@ func init() {
 }
 
 func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	viper.BindPFlag("realm-management.url", cmd.Flags().Lookup("realm-management-url"))
-	viper.BindPFlag("realm.key", cmd.Flags().Lookup("realm-key"))
+	viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
+	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(
-		map[misc.AstarteService]string{misc.RealmManagement: "realm-management.url"}, "realm.key")
+		map[misc.AstarteService]string{misc.RealmManagement: "individual-urls.realm-management."}, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
-	github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0
+	github.com/astarte-platform/astarte-go v0.0.0-20200326130039-e71af3170c16
 	github.com/go-openapi/strfmt v0.19.3 // indirect
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0 h1:SWreefmOXzzhm2fmQH+jycj5f3zcVx8fvWBtVa4g9CY=
-github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0/go.mod h1:qdLuKqljGJ4ncKpidJVUQOwvMi20idQw31Y4cd39yjs=
+github.com/astarte-platform/astarte-go v0.0.0-20200326130039-e71af3170c16 h1:O676RvZUDUYVf0V1z0LItelf6S90DU79nmEy8nCWZ5s=
+github.com/astarte-platform/astarte-go v0.0.0-20200326130039-e71af3170c16/go.mod h1:qdLuKqljGJ4ncKpidJVUQOwvMi20idQw31Y4cd39yjs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
This also slightly changes internal semantics to allow loading keys both from files and base64 strings (also updates astarte-go to use some new, required, APIs)