### PR TITLE
Add realm-management interfaces sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.0-rc.1] - Unreleased
+### Added
+- Add `realm-management interfaces sync` subcommand
+
 ### Fixed
 - appengine: Fix crash when retrieving nil values out of device interfaces
 - appengine: Fix panic when passing appengine-url without realmmanagement-url (#73)

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -145,7 +145,11 @@ func interfacesShowF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	respJSON, _ := json.MarshalIndent(interfaceDefinition, "", "  ")
+	respJSON, err := json.MarshalIndent(interfaceDefinition, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	fmt.Println(string(respJSON))
 	return nil
 }
@@ -157,13 +161,11 @@ func interfacesInstallF(command *cobra.Command, args []string) error {
 	}
 
 	var interfaceBody interfaces.AstarteInterface
-	err = json.Unmarshal(interfaceFile, &interfaceBody)
-	if err != nil {
+	if err = json.Unmarshal(interfaceFile, &interfaceBody); err != nil {
 		return err
 	}
 
-	err = astarteAPIClient.RealmManagement.InstallInterface(realm, interfaceBody)
-	if err != nil {
+	if err = astarteAPIClient.RealmManagement.InstallInterface(realm, interfaceBody); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -176,8 +178,7 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
 	interfaceMajor := 0
 
-	err := astarteAPIClient.RealmManagement.DeleteInterface(realm, interfaceName, interfaceMajor)
-	if err != nil {
+	if err := astarteAPIClient.RealmManagement.DeleteInterface(realm, interfaceName, interfaceMajor); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -193,14 +194,12 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 	}
 
 	var astarteInterface interfaces.AstarteInterface
-	err = json.Unmarshal(interfaceFile, &astarteInterface)
-	if err != nil {
+	if err = json.Unmarshal(interfaceFile, &astarteInterface); err != nil {
 		return err
 	}
 
-	err = astarteAPIClient.RealmManagement.UpdateInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion,
-		astarteInterface)
-	if err != nil {
+	if err = astarteAPIClient.RealmManagement.UpdateInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion,
+		astarteInterface); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR adds a subcommand to synchronize a number of Interface files with the Realm state, avoiding the pain to check whether any interface file is missing or out of date with the Realm. It iterates over all files, checks the state of the realm upstream, and piles up all the correct operations to be done to ensure the Realm state matches the local files.