### PR TITLE
Add astartectl devices send-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0-rc.1] - Unreleased
 ### Added
 - Add `realm-management interfaces sync` subcommand
+- Add `appengine devices send-data` subcommand
 
 ### Fixed
 - appengine: Fix crash when retrieving nil values out of device interfaces

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -15,9 +15,12 @@
 package appengine
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -94,6 +97,24 @@ this is automatically determined - however, you can tweak this behavior by using
 	RunE:    devicesGetSamplesF,
 }
 
+var devicesSendDataCmd = &cobra.Command{
+	Use:   "send-data <device_id_or_alias> <interface_name> <path> <data>",
+	Short: "Sends data to a given interface path",
+	Long: `Sends data to a given interface path. This works both for datastream with individual and properties.
+
+When dealing with an aggregate, non parametric interface, path must still be provided, adhering to the
+interface structure. In that case, <data> should be a JSON string which contains a key/value dictionary,
+with key bearing the name (without trailing slashes) of the tip of the endpoint, and value being the
+value of that specific endpoint, correctly typed.
+
+<device_id_or_alias> can be either a valid Astarte Device ID, or a Device Alias. In most cases,
+this is automatically determined - however, you can tweak this behavior by using --force-device-id or
+--force-id-type={device-id,alias}.`,
+	Example: `  astartectl appengine devices send-data 2TBn-jNESuuHamE2Zo1anA com.my.interface /my/path "value"`,
+	Args:    cobra.ExactArgs(4),
+	RunE:    devicesSendDataF,
+}
+
 var supportedOutputTypes = []string{"default", "csv", "json"}
 
 func isASupportedOutputType(outputType string) bool {
@@ -122,6 +143,11 @@ func init() {
 	devicesDataSnapshotCmd.Flags().Bool("skip-realm-management-checks", false, "When set, it skips any consistency checks on Realm Management before performing the Query. This might lead to unexpected errors. This has effect only if data-snapshot is invoked for a specific interface.")
 	devicesDataSnapshotCmd.Flags().String("interface-type", "", "When set, if Realm Management checks are disabled, it forces resolution of the interface as the specified type. Valid options are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream.")
 
+	devicesSendDataCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
+	devicesSendDataCmd.Flags().Bool("skip-realm-management-checks", false, "When set, it skips any consistency checks on Realm Management before performing the Query. This might lead to unexpected errors. This has effect only if data-snapshot is invoked for a specific interface.")
+	devicesSendDataCmd.Flags().String("interface-type", "", "When set, if Realm Management checks are disabled, it forces resolution of the interface as the specified type. Valid options are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream.")
+	devicesSendDataCmd.Flags().String("payload-type", "", "When set, forces the conversion of the given payload into the given type. Valid values are any value in Astarte interfaces.")
+
 	devicesShowCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
 
 	devicesCmd.AddCommand(
@@ -129,6 +155,7 @@ func init() {
 		devicesShowCmd,
 		devicesDataSnapshotCmd,
 		devicesGetSamplesCmd,
+		devicesSendDataCmd,
 	)
 }
 
@@ -297,72 +324,15 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 			interfacesToFetch = append(interfacesToFetch, interfaceDescription)
 		}
 	} else {
-		interfaceType := interfaces.DatastreamType
-		interfaceAggregation := interfaces.IndividualAggregation
-		isParametricInterface := false
-		// Be slightly smarter - also, fail early if we cannot find the interface
-		if skipRealmManagementChecks {
-			switch interfaceTypeString {
-			case "properties":
-				interfaceType = interfaces.PropertiesType
-			case "individual-datastream":
-			case "aggregate-datastream":
-				interfaceAggregation = interfaces.ObjectAggregation
-			case "individual-parametric-datastream":
-				isParametricInterface = true
-			case "aggregate-parametric-datastream":
-				interfaceAggregation = interfaces.ObjectAggregation
-				isParametricInterface = true
-			default:
-				return fmt.Errorf("%s is not a valid Interface Type. Valid interface types are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream", interfaceTypeString)
-			}
-			fakeInterface := interfaces.AstarteInterface{
-				Name:        snapshotInterface,
-				Type:        interfaceType,
-				Aggregation: interfaceAggregation,
-			}
-			// Just a trick to trick the parser into doing the right thing.
-			if isParametricInterface {
-				fakeInterface.Mappings = []interfaces.AstarteInterfaceMapping{
-					interfaces.AstarteInterfaceMapping{
-						Endpoint: "/it/%{is}/parametric",
-					},
-				}
-			}
-			interfacesToFetch = []interfaces.AstarteInterface{fakeInterface}
-		} else {
-			// Get the device introspection
-			deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
-			if err != nil {
-				return err
-			}
-
-			for astarteInterface, interfaceIntrospection := range deviceDetails.Introspection {
-				if astarteInterface != snapshotInterface {
-					continue
-				}
-
-				// Query Realm Management to get details on the interface
-				interfaceDescription, err := astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface,
-					interfaceIntrospection.Major)
-				if err != nil {
-					// Die here, given we really can't recover further
-					fmt.Println(err.Error())
-					os.Exit(1)
-				}
-				interfaceType = interfaceDescription.Type
-				interfacesToFetch = []interfaces.AstarteInterface{interfaceDescription}
-				break
-			}
-
-			if len(interfacesToFetch) == 0 {
-				fmt.Printf("Interface %s does not exist in Device %s\n", snapshotInterface, deviceID)
-				os.Exit(1)
-			}
+		// Get the proto interface
+		iface, err := getProtoInterface(deviceID, deviceIdentifierType, snapshotInterface, interfaceTypeString, skipRealmManagementChecks)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
 		}
 
 		// We're dealing with only one interface, so let's be as smart as possible.
-		switch interfaceType {
+		switch iface.Type {
 		case interfaces.DatastreamType:
 			t.AppendHeader(table.Row{"Interface", "Path", "Value", "Timestamp"})
 		case interfaces.PropertiesType:
@@ -677,6 +647,179 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 	return nil
 }
 
+func devicesSendDataF(command *cobra.Command, args []string) error {
+	deviceID := args[0]
+	interfaceName := args[1]
+	interfacePath := args[2]
+	payloadData := args[3]
+	forceIDType, err := command.Flags().GetString("force-id-type")
+	if err != nil {
+		return err
+	}
+	deviceIdentifierType, err := deviceIdentifierTypeFromFlags(deviceID, forceIDType)
+	if err != nil {
+		return err
+	}
+	skipRealmManagementChecks, err := command.Flags().GetBool("skip-realm-management-checks")
+	if err != nil {
+		return err
+	}
+	skipRealmManagementChecks = skipRealmManagementChecks || astarteAPIClient.RealmManagement == nil
+	interfaceTypeString, err := command.Flags().GetString("interface-type")
+	if err != nil {
+		return err
+	}
+	if skipRealmManagementChecks && interfaceTypeString == "" {
+		return fmt.Errorf("When not using Realm Management checks, --interface-type should always be specified")
+	}
+
+	iface, err := getProtoInterface(deviceID, deviceIdentifierType, interfaceName, interfaceTypeString, skipRealmManagementChecks)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if !skipRealmManagementChecks {
+		if iface.Ownership != interfaces.ServerOwnership {
+			fmt.Println("send-data makes sense only for server-owned interfaces")
+			os.Exit(1)
+		}
+	}
+
+	// Time to understand the payload type
+	payloadTypeString, err := command.Flags().GetString("payload-type")
+	if err != nil {
+		return err
+	}
+	if skipRealmManagementChecks && payloadTypeString == "" {
+		switch interfaceTypeString {
+		case "aggregate-datastream", "aggregate-parametric-datastream":
+			// In this case, it's ok not to pass anything as the type
+		default:
+			return fmt.Errorf("When not using Realm Management checks with interfaces with individual aggregation, --payload-type should always be specified")
+		}
+	}
+
+	// Assign a payload Type only if it's not an aggregate
+	var payloadType interfaces.AstarteMappingType
+	if payloadTypeString != "" {
+		payloadType = interfaces.AstarteMappingType(payloadTypeString)
+		if err := payloadType.IsValid(); err != nil {
+			// It's an input error, so return err
+			return err
+		}
+	} else if !skipRealmManagementChecks && iface.Aggregation == interfaces.IndividualAggregation {
+		if payloadType == "" {
+			mapping, err := interfaces.InterfaceMappingFromPath(iface, interfacePath)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+			payloadType = mapping.Type
+		}
+	}
+
+	var parsedPayloadData interface{}
+	if err := payloadType.IsValid(); err == nil {
+		if parsedPayloadData, err = parseSendDataPayload(payloadData, payloadType); err != nil {
+			return err
+		}
+	} else {
+		// We have to treat it as an aggregate.
+		aggrPayload := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(payloadData), &aggrPayload); err != nil {
+			return err
+		}
+		parsedPayloadData = aggrPayload
+	}
+
+	if !skipRealmManagementChecks {
+		// We can delegate the entirety of this to astarte-go
+		err = astarteAPIClient.AppEngine.SendData(realm, deviceID, deviceIdentifierType, iface, interfacePath, parsedPayloadData)
+	} else {
+		// Don't risk it. Use raw functions and trust the server to fail, in case.
+		switch interfaceTypeString {
+		case "properties":
+			err = astarteAPIClient.AppEngine.SetProperty(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+		case "individual-datastream", "individual-parametric-datastream":
+			err = astarteAPIClient.AppEngine.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+		case "aggregate-datastream", "aggregate-parametric-datastream":
+			err = astarteAPIClient.AppEngine.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+		default:
+			err = fmt.Errorf("%s is not a valid Interface Type. Valid interface types are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream", interfaceTypeString)
+		}
+	}
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Done
+	fmt.Println("ok")
+	return nil
+}
+
+func getProtoInterface(deviceID string, deviceIdentifierType client.DeviceIdentifierType,
+	interfaceName, interfaceTypeString string, skipRealmManagementChecks bool) (interfaces.AstarteInterface, error) {
+	iface := interfaces.AstarteInterface{}
+
+	if skipRealmManagementChecks {
+		interfaceType := interfaces.DatastreamType
+		interfaceAggregation := interfaces.IndividualAggregation
+		isParametricInterface := false
+		switch interfaceTypeString {
+		case "properties":
+			interfaceType = interfaces.PropertiesType
+		case "individual-datastream":
+		case "aggregate-datastream":
+			interfaceAggregation = interfaces.ObjectAggregation
+		case "individual-parametric-datastream":
+			isParametricInterface = true
+		case "aggregate-parametric-datastream":
+			interfaceAggregation = interfaces.ObjectAggregation
+			isParametricInterface = true
+		default:
+			return iface, fmt.Errorf("%s is not a valid Interface Type. Valid interface types are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream", interfaceTypeString)
+		}
+		iface = interfaces.AstarteInterface{
+			Name:        interfaceName,
+			Type:        interfaceType,
+			Aggregation: interfaceAggregation,
+		}
+		// Just a trick to trick the parser into doing the right thing.
+		if isParametricInterface {
+			iface.Mappings = []interfaces.AstarteInterfaceMapping{
+				interfaces.AstarteInterfaceMapping{
+					Endpoint: "/it/%{is}/parametric",
+				},
+			}
+		}
+	} else {
+		// Get the device introspection
+		deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
+		if err != nil {
+			return iface, err
+		}
+
+		for astarteInterface, interfaceIntrospection := range deviceDetails.Introspection {
+			if astarteInterface != interfaceName {
+				continue
+			}
+
+			// Query Realm Management to get details on the interface
+			iface, err = astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface,
+				interfaceIntrospection.Major)
+			if err != nil {
+				// Die here, given we really can't recover further
+				return iface, err
+			}
+			break
+		}
+	}
+
+	return iface, nil
+}
+
 func timestampForOutput(timestamp time.Time, outputType string) string {
 	switch outputType {
 	case "default":
@@ -699,4 +842,56 @@ func renderOutput(t table.Writer, jsonOutput interface{}, outputType string) {
 		respJSON, _ := json.MarshalIndent(jsonOutput, "", "  ")
 		fmt.Println(string(respJSON))
 	}
+}
+
+func parseSendDataPayload(payload string, mappingType interfaces.AstarteMappingType) (interface{}, error) {
+	// Default to string, as it will be ok for most cases
+	var ret interface{} = payload
+	var err error
+	switch mappingType {
+	case interfaces.Double:
+		if ret, err = strconv.ParseFloat(payload, 64); err != nil {
+			return nil, err
+		}
+	case interfaces.Integer, interfaces.LongInteger:
+		if ret, err = strconv.ParseInt(payload, 10, 64); err != nil {
+			return nil, err
+		}
+	case interfaces.Boolean:
+		if ret, err = strconv.ParseBool(payload); err != nil {
+			return nil, err
+		}
+	case interfaces.BinaryBlob:
+		// We have to verify base64 decoding works
+		if _, err := base64.StdEncoding.DecodeString(payload); err != nil {
+			return nil, err
+		}
+	case interfaces.DateTime:
+		if ret, err = dateparse.ParseAny(payload); err != nil {
+			return nil, err
+		}
+	case interfaces.BinaryBlobArray, interfaces.BooleanArray, interfaces.DateTimeArray, interfaces.DoubleArray,
+		interfaces.IntegerArray, interfaces.LongIntegerArray, interfaces.StringArray:
+		var jsonOut []interface{}
+		if err := json.Unmarshal([]byte(payload), &jsonOut); err != nil {
+			return nil, err
+		}
+		retArray := []interface{}{}
+		// Do a smarter conversion here.
+		for _, v := range jsonOut {
+			switch val := v.(type) {
+			case string:
+				p, err := parseSendDataPayload(val, interfaces.AstarteMappingType(strings.TrimSuffix(string(mappingType), "array")))
+				if err != nil {
+					return nil, err
+				}
+				retArray = append(retArray, p)
+			default:
+				retArray = append(retArray, val)
+			}
+		}
+		ret = retArray
+	}
+
+	return ret, nil
 }

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -390,7 +390,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 									v = "(null)"
 								}
 								if snapshotInterface == "" {
-									t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v, i.Ownership.String(),
+									t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v, i.Ownership,
 										timestampForOutput(aggregate.Timestamp, outputType)})
 								} else {
 									t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v,
@@ -413,7 +413,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 								v = "(null)"
 							}
 							if snapshotInterface == "" {
-								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("/%s", k), v, i.Ownership.String(),
+								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("/%s", k), v, i.Ownership,
 									timestampForOutput(val.Timestamp, outputType)})
 							} else {
 								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("/%s", k), v,
@@ -434,7 +434,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 						v.Value = "(null)"
 					}
 					if snapshotInterface == "" {
-						t.AppendRow([]interface{}{i.Name, k, v.Value, i.Ownership.String(),
+						t.AppendRow([]interface{}{i.Name, k, v.Value, i.Ownership,
 							timestampForOutput(v.Timestamp, outputType)})
 					} else {
 						t.AppendRow([]interface{}{i.Name, k, v.Value,
@@ -455,7 +455,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 					v = "(null)"
 				}
 				if snapshotInterface == "" {
-					t.AppendRow([]interface{}{i.Name, k, v, i.Ownership.String(), ""})
+					t.AppendRow([]interface{}{i.Name, k, v, i.Ownership, ""})
 				} else {
 					t.AppendRow([]interface{}{i.Name, k, v})
 				}

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -27,7 +27,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/astarte-platform/astartectl/cmd/cluster/deployment"
 	"github.com/astarte-platform/astartectl/utils"
-	"github.com/google/go-github/v28/github"
+	"github.com/google/go-github/v30/github"
 	"github.com/spf13/cobra"
 	appsv1 "k8s.io/api/apps/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
-	github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0
+	github.com/astarte-platform/astarte-go v0.0.0-20200401101859-900ce3bfec04
 	github.com/go-openapi/strfmt v0.19.3 // indirect
-	github.com/google/go-github/v28 v28.1.1
+	github.com/google/go-github/v30 v30.1.0
 	github.com/google/uuid v1.1.1
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/mattn/go-runewidth v0.0.4 // indirect
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
-	github.com/spf13/cobra v0.0.6
+	github.com/spf13/cobra v0.0.7
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.2
@@ -28,5 +28,5 @@ require (
 	k8s.io/apiextensions-apiserver v0.0.0-20191114105316-e8706470940d
 	k8s.io/apimachinery v0.0.0-20191004115701-31ade1b30762
 	k8s.io/client-go v0.0.0-20191114101336-8cba805ad12d
-	sigs.k8s.io/yaml v1.1.0
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0 h1:SWreefmOXzzhm2fmQH+jycj5f3zcVx8fvWBtVa4g9CY=
-github.com/astarte-platform/astarte-go v0.0.0-20200325111501-f4460a6ad5f0/go.mod h1:qdLuKqljGJ4ncKpidJVUQOwvMi20idQw31Y4cd39yjs=
+github.com/astarte-platform/astarte-go v0.0.0-20200401101859-900ce3bfec04 h1:/QctoZiO3K6O3LhMRJp5D9io9izwYaPt/5DApjoN0ek=
+github.com/astarte-platform/astarte-go v0.0.0-20200401101859-900ce3bfec04/go.mod h1:qdLuKqljGJ4ncKpidJVUQOwvMi20idQw31Y4cd39yjs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -120,13 +120,15 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
-github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
+github.com/google/go-github/v30 v30.1.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
@@ -256,8 +258,8 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.0-20180319062004-c439c4fa0937/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
-github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v0.0.7 h1:FfTH+vuMXOas8jmfb5/M7dzEYx7LpcLb7a0LPe34uOU=
+github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
@@ -326,7 +328,6 @@ golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -422,3 +423,5 @@ sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2 h1:9r5DY45e
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
+sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/utils/client.go
+++ b/utils/client.go
@@ -63,7 +63,7 @@ func APICommandSetup(individualURLVariables map[misc.AstarteService]string, keyV
 			servicesAndClaims[k] = []string{}
 		}
 		// 1 minute TTL is more than enough for our purposes
-		if err := astarteAPIClient.SetTokenFromPrivateKeyWithClaims(privateKey, servicesAndClaims, 60); err != nil {
+		if err := astarteAPIClient.SetTokenFromPrivateKeyFileWithClaims(privateKey, servicesAndClaims, 60); err != nil {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
Here finally comes a way to send data to devices through astartectl. send-data allows interacting with server-owned interfaces in any scenario, and enables astartectl to also communicate southbound with devices