### PR TITLE
Integrate new context-based config in existing commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `cluster instance get-cluster-config` allows getting a cluster configuration out of the
+  current cluster
+
+### Changed
+- astartectl configuration now works through a context system, kubectl-style
+- `cluster instance deploy` now creates a new cluster config context upon successful cluster creation
+- `housekeeping realms create` has completely different (and incompatible) semantics: it now allows supplying
+  either a public, private or no key, and will create a new config context accordingly
+
 ## [0.11.0-rc.1] - Unreleased
 ### Fixed
 - appengine: Fix crash when retrieving nil values out of device interfaces

--- a/cmd/cluster/instance_change_profile.go
+++ b/cmd/cluster/instance_change_profile.go
@@ -24,7 +24,6 @@ import (
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
 	"k8s.io/apimachinery/pkg/util/mergepatch"
@@ -48,12 +47,6 @@ func init() {
 }
 
 func instanceChangeProfileF(command *cobra.Command, args []string) error {
-	astartes, err := listAstartes()
-	if err != nil || len(astartes) == 0 {
-		fmt.Println("No Managed Astarte installations found.")
-		return nil
-	}
-
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
@@ -64,17 +57,8 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 		resourceNamespace = "astarte"
 	}
 
-	var astarteObject *unstructured.Unstructured = nil
-	for _, v := range astartes {
-		for _, res := range v.Items {
-			if res.Object["metadata"].(map[string]interface{})["namespace"] == resourceNamespace && res.Object["metadata"].(map[string]interface{})["name"] == resourceName {
-				astarteObject = res.DeepCopy()
-				break
-			}
-		}
-	}
-
-	if astarteObject == nil {
+	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
+	if err != nil {
 		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
 		os.Exit(1)
 	}

--- a/cmd/cluster/instance_destroy.go
+++ b/cmd/cluster/instance_destroy.go
@@ -22,7 +22,6 @@ import (
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var destroyCmd = &cobra.Command{
@@ -44,12 +43,6 @@ func init() {
 }
 
 func clusterDestroyF(command *cobra.Command, args []string) error {
-	astartes, err := listAstartes()
-	if err != nil || len(astartes) == 0 {
-		fmt.Println("No Managed Astarte installations found.")
-		return nil
-	}
-
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
@@ -65,17 +58,7 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	var astarteObject *unstructured.Unstructured = nil
-	for _, v := range astartes {
-		for _, res := range v.Items {
-			if res.Object["metadata"].(map[string]interface{})["namespace"] == resourceNamespace && res.Object["metadata"].(map[string]interface{})["name"] == resourceName {
-				astarteObject = res.DeepCopy()
-				break
-			}
-		}
-	}
-
-	if astarteObject == nil {
+	if _, err := getAstarteInstance(resourceName, resourceNamespace); err != nil {
 		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
 		os.Exit(1)
 	}

--- a/cmd/cluster/instance_get_cluster_config.go
+++ b/cmd/cluster/instance_get_cluster_config.go
@@ -52,6 +52,10 @@ func instancesGetClusterConfigF(command *cobra.Command, args []string) error {
 		resourceNamespace = "astarte"
 	}
 
+	return doGetClusterConfig(resourceName, resourceNamespace)
+}
+
+func doGetClusterConfig(resourceName, resourceNamespace string) error {
 	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
 	if err != nil {
 		fmt.Printf("Error while looking for instance %s: %s.\n", resourceName, err.Error())

--- a/cmd/cluster/instance_get_cluster_config.go
+++ b/cmd/cluster/instance_get_cluster_config.go
@@ -1,0 +1,119 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/spf13/cobra"
+)
+
+var getClusterConfigCmd = &cobra.Command{
+	Use:   "get-cluster-config <name>",
+	Short: "Gets the current cluster config for instance <name> and updates your local Astarte configuration",
+	Long: `Fetches the current cluster config for instance <name>, including the Cluster URL and its
+housekeeping key, and adds it to your cluster and context configuration. A new cluster entry
+will be created, together with a new context matching the cluster, without an associated realm.`,
+	Example: `  astartectl cluster instances get-cluster-config`,
+	RunE:    instancesGetClusterConfigF,
+	Args:    cobra.ExactArgs(1),
+}
+
+func init() {
+	getClusterConfigCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
+
+	InstancesCmd.AddCommand(getClusterConfigCmd)
+}
+
+func instancesGetClusterConfigF(command *cobra.Command, args []string) error {
+	resourceName := args[0]
+	resourceNamespace, err := command.Flags().GetString("namespace")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	if resourceNamespace == "" {
+		resourceNamespace = "astarte"
+	}
+
+	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
+	if err != nil {
+		fmt.Printf("Error while looking for instance %s: %s.\n", resourceName, err.Error())
+		os.Exit(1)
+	}
+	astarteSpec := astarteObject.Object["spec"].(map[string]interface{})
+
+	astarteHost := astarteSpec["api"].(map[string]interface{})["host"].(string)
+	astarteURL := url.URL{
+		Host:   astarteSpec["api"].(map[string]interface{})["host"].(string),
+		Scheme: "https",
+	}
+
+	clusterName := fmt.Sprintf("%s-%s-cluster", resourceName, astarteHost)
+
+	// Fetch key
+	keyData, err := getHousekeepingKey(resourceName, resourceNamespace, false)
+	if err != nil {
+		fmt.Printf("Error while fetching Housekeeping Key for instance %s: %s.\n", resourceName, err.Error())
+		os.Exit(1)
+	}
+
+	clusterConfig := config.ClusterFile{
+		URL: astarteURL.String(),
+		Housekeeping: config.HousekeepingConfiguration{
+			Key: base64.StdEncoding.EncodeToString(keyData),
+		},
+	}
+
+	configDir := config.GetConfigDir()
+
+	if err := config.SaveClusterConfiguration(configDir, clusterName, clusterConfig); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Created new Cluster configuration %s\n", clusterName)
+
+	// Add a Context now
+	contextName := fmt.Sprintf("%s-%s-global", resourceName, astarteHost)
+	contextConfig := config.ContextFile{
+		Cluster: clusterName,
+	}
+	if err := config.SaveContextConfiguration(configDir, contextName, contextConfig); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Created new Context %s\n", contextName)
+
+	// Now set the current context to the new one
+	baseConfig, err := config.LoadBaseConfiguration(configDir)
+	if err != nil {
+		// Shoot out a warning, but don't fail
+		baseConfig = config.BaseConfigFile{}
+		fmt.Fprintf(os.Stderr, "warn: Could not load configuration file: %s. Will proceed creating a new one\n", err.Error())
+	}
+
+	baseConfig.CurrentContext = contextName
+	if err := config.SaveBaseConfiguration(configDir, baseConfig); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	fmt.Printf("Context switched to %s\n", contextName)
+
+	return nil
+}

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -15,14 +15,26 @@
 package housekeeping
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // realmsCmd represents the realms command
@@ -63,9 +75,16 @@ var realmsCreateCmd = &cobra.Command{
 func init() {
 	HousekeepingCmd.AddCommand(realmsCmd)
 
-	realmsCreateCmd.Flags().StringP("public-key", "p", "", "Path to PEM encoded public key used as realm key")
-	realmsCreateCmd.MarkFlagRequired("public-key")
-	realmsCreateCmd.MarkFlagFilename("public-key")
+	realmsCreateCmd.Flags().String("realm-private-key", "", "Path to PEM encoded public key used as realm key")
+	if err := realmsCreateCmd.MarkFlagFilename("realm-private-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	realmsCreateCmd.Flags().String("realm-public-key", "", "Path to PEM encoded public key used as realm key")
+	if err := realmsCreateCmd.MarkFlagFilename("realm-public-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	realmsCreateCmd.Flags().IntP("replication-factor", "r", 0, `Replication factor for the realm, used with SimpleStrategy replication.`)
 	realmsCreateCmd.Flags().StringSliceP("datacenter-replication", "d", nil,
 		`Replication factor for a datacenter, used with NetworkTopologyStrategy replication.
@@ -106,14 +125,16 @@ func realmsShowF(command *cobra.Command, args []string) error {
 
 func realmsCreateF(command *cobra.Command, args []string) error {
 	realm := args[0]
-	publicKey, err := command.Flags().GetString("public-key")
+	publicKey, err := command.Flags().GetString("realm-public-key")
 	if err != nil {
 		return err
 	}
-
-	publicKeyContent, err := ioutil.ReadFile(publicKey)
+	privateKey, err := command.Flags().GetString("realm-private-key")
 	if err != nil {
 		return err
+	}
+	if privateKey != "" && publicKey != "" {
+		return errors.New("when passing --realm-private-key, --realm-public-key should not be specified")
 	}
 
 	replicationFactor, err := command.Flags().GetInt("replication-factor")
@@ -130,10 +151,17 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 		return errors.New("replication-factor and datacenter-replication are mutually exclusive, you only have to specify one")
 	}
 
-	if replicationFactor > 0 {
-		err = astarteAPIClient.Housekeeping.CreateRealmWithReplicationFactor(realm, string(publicKeyContent), replicationFactor)
-	} else if len(datacenterReplications) > 0 {
-		datacenterReplicationFactors := make(map[string]int)
+	createContext := true
+	clusterConfigurationName, err := getClusterNameFromURLs()
+	if err != nil {
+		createContext = false
+	}
+	if privateKey == "" && publicKey != "" {
+		createContext = false
+	}
+
+	datacenterReplicationFactors := make(map[string]int)
+	if len(datacenterReplications) > 0 {
 		for _, datacenterString := range datacenterReplications {
 			tokens := strings.Split(datacenterString, ":")
 			if len(tokens) != 2 {
@@ -148,6 +176,106 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 			}
 			datacenterReplicationFactors[datacenter] = datacenterReplicationFactor
 		}
+	}
+
+	urlString := viper.GetString("url")
+	if viper.GetString("individual-urls.housekeeping") != "" {
+		urlString = viper.GetString("individual-urls.housekeeping")
+	}
+	astarteURL, err := url.Parse(urlString)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	contextName := ""
+	if createContext {
+		contextName = fmt.Sprintf("%s-realm-%s", astarteURL.Hostname(), realm)
+	}
+
+	fmt.Println("Will create Astarte Realm with following parameters:")
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	fmt.Fprintf(w, "Astarte Cluster API Host:\t%s\n", astarteURL.Hostname())
+	fmt.Fprintf(w, "Realm name:\t%s\n", realm)
+	if len(datacenterReplicationFactors) > 0 {
+		fmt.Fprint(w, "Datacenter replications:")
+		for k, v := range datacenterReplicationFactors {
+			fmt.Fprintf(w, "\t%s: %d\n", k, v)
+		}
+	} else {
+		printedReplicationFactor := replicationFactor
+		if replicationFactor == 0 {
+			printedReplicationFactor = 1
+		}
+		fmt.Fprintf(w, "Replication factor:\t%d\n", printedReplicationFactor)
+	}
+	if createContext {
+		fmt.Fprintf(w, "Astarte Context:\t%s\n", contextName)
+	}
+	w.Flush()
+	fmt.Println()
+
+	if !createContext {
+		fmt.Println("Will not create an Astarte context - to do so, you need to have a matching Astarte Cluster configuration and supply a private key for the Realm.")
+		fmt.Println()
+	}
+
+	if privateKey == "" && publicKey == "" {
+		fmt.Println("A new private key will be generated for this realm and saved in your configuration.")
+		fmt.Printf("You will be able to access it with \"astartectl config contexts get-realm-key %s\".\n", contextName)
+		fmt.Println()
+	}
+
+	if ok, err := utils.AskForConfirmation("Do you want to continue?"); !ok || err != nil {
+		os.Exit(0)
+	}
+
+	var publicKeyContent []byte
+	var privateKeyContent []byte
+	switch {
+	case publicKey != "":
+		publicKeyContent, err = ioutil.ReadFile(publicKey)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	case privateKey != "":
+		privateKeyContent, err = ioutil.ReadFile(privateKey)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyContent)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if publicKeyContent, err = getPublicKeyPEMBytes(&key.PublicKey); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	default:
+		reader := rand.Reader
+		bitSize := 4096
+		key, err := rsa.GenerateKey(reader, bitSize)
+		if err != nil {
+			return err
+		}
+
+		if privateKeyContent, err = getPrivateKeyPEMBytes(key); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		if publicKeyContent, err = getPublicKeyPEMBytes(&key.PublicKey); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
+
+	if replicationFactor > 0 {
+		err = astarteAPIClient.Housekeeping.CreateRealmWithReplicationFactor(realm, string(publicKeyContent), replicationFactor)
+	} else if len(datacenterReplicationFactors) > 0 {
 		err = astarteAPIClient.Housekeeping.CreateRealmWithDatacenterReplication(realm, string(publicKeyContent),
 			datacenterReplicationFactors)
 	} else {
@@ -159,6 +287,106 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	fmt.Println("ok")
+	fmt.Printf("Realm %s created successfully!\n", realm)
+
+	// If we're not creating a context, return
+	if !createContext {
+		return nil
+	}
+
+	realmContext := config.RealmConfiguration{
+		Name: realm,
+	}
+
+	if privateKeyContent != nil {
+		realmContext.Key = base64.StdEncoding.EncodeToString(privateKeyContent)
+	}
+
+	configContext := config.ContextFile{
+		Cluster: clusterConfigurationName,
+		Realm:   realmContext,
+	}
+
+	configDir := config.GetConfigDir()
+	if err := config.SaveContextConfiguration(configDir, contextName, configContext); err != nil {
+		fmt.Printf("Could not save cluster configuration: %s\n", err)
+		if privateKey == "" {
+			// Dump the private key
+			fmt.Println("Dumping private key for reference")
+			fmt.Println(string(privateKeyContent))
+		}
+	} else {
+		fmt.Printf("Context %s created successfully\n", contextName)
+
+		// Now set the current context to the new one
+		baseConfig, err := config.LoadBaseConfiguration(configDir)
+		if err != nil {
+			// Shoot out a warning, but don't fail
+			baseConfig = config.BaseConfigFile{}
+			fmt.Fprintf(os.Stderr, "warn: Could not load configuration file: %s. Will proceed creating a new one\n", err.Error())
+		}
+
+		baseConfig.CurrentContext = contextName
+		if err := config.SaveBaseConfiguration(configDir, baseConfig); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, "warn: Context not switched")
+		} else {
+			fmt.Printf("Context switched to %s\n", contextName)
+		}
+	}
+
 	return nil
+}
+
+func getPrivateKeyPEMBytes(key *rsa.PrivateKey) ([]byte, error) {
+	var pemkey = &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	var outbuf bytes.Buffer
+
+	if err := pem.Encode(&outbuf, pemkey); err != nil {
+		return nil, err
+	}
+
+	return outbuf.Bytes(), nil
+}
+
+func getPublicKeyPEMBytes(key *rsa.PublicKey) ([]byte, error) {
+	pkixBytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return nil, err
+	}
+	var pemkey = &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: pkixBytes,
+	}
+	var outbuf bytes.Buffer
+
+	if err := pem.Encode(&outbuf, pemkey); err != nil {
+		return nil, err
+	}
+
+	return outbuf.Bytes(), nil
+}
+
+func getClusterNameFromURLs() (string, error) {
+	configDir := config.GetConfigDir()
+	clusters, err := config.ListClusterConfigurations(configDir)
+	if err == nil {
+		for _, c := range clusters {
+			cluster, err := config.LoadClusterConfiguration(configDir, c)
+			if err != nil {
+				continue
+			}
+			if cluster.IndividualURLs.Housekeeping == viper.GetString("individual-urls.housekeeping") || cluster.URL == viper.GetString("url") {
+				// yay
+				return c, nil
+			}
+		}
+	} else {
+		return "", err
+	}
+	// Skip context creation
+	return "", errors.New("Not found")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgDir, cfgContext string
+var cfgContext string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -60,10 +60,14 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
-	rootCmd.PersistentFlags().StringVar(&cfgDir, "config-dir", "", fmt.Sprintf("config directory (default is %s)", config.GetDefaultConfigDir()))
+	rootCmd.PersistentFlags().String("config-dir", "", fmt.Sprintf("config directory (default is %s)", config.GetDefaultConfigDir()))
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Configuration context to use. When not specified, defaults to current context.")
 	rootCmd.PersistentFlags().StringP("astarte-url", "u", "", "Base url for your Astarte deployment (e.g. https://api.astarte.example.com)")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Token for authenticating against Astarte APIs. When set, it takes precedence over any private key setting. Claims in the token have to match the permissions needed for the individual command.")
+	if err := viper.BindPFlag("config-dir", rootCmd.PersistentFlags().Lookup("config-dir")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("astarte-url"))
 	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
 
@@ -77,7 +81,7 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if err := config.ConfigureViper(cfgDir, cfgContext); err != nil {
+	if err := config.ConfigureViper(cfgContext); err != nil {
 		fmt.Fprintf(os.Stderr, "warn: Error while loading configuration: %s\n", err.Error())
 	}
 

--- a/config/utils.go
+++ b/config/utils.go
@@ -28,14 +28,9 @@ import (
 // ConfigureViper sets up Viper to behave correctly with regards to both context and
 // configuration directory, taking into account all environment variables and parameters.
 // Order of precedence is: override, environment variables, defaults
-func ConfigureViper(configDirOverride, contextOverride string) error {
+func ConfigureViper(contextOverride string) error {
 	// Get configuration directory, first of all
-	configDir := GetDefaultConfigDir()
-	if configDirOverride != "" {
-		configDir = configDirOverride
-	} else if dirFromEnv, ok := os.LookupEnv("ASTARTE_CONFIG_DIR"); ok && dirFromEnv != "" {
-		configDir = dirFromEnv
-	}
+	configDir := GetConfigDir()
 	// Check if it exists
 	if _, err := os.Stat(configDir); err != nil {
 		return err
@@ -85,6 +80,17 @@ func ConfigureViper(configDirOverride, contextOverride string) error {
 	return nil
 }
 
+// GetConfigDir returns the Config Dir based on the current status
+func GetConfigDir() string {
+	configDir := GetDefaultConfigDir()
+	if configDirOverride := viper.GetString("config-dir"); configDirOverride != "" {
+		configDir = configDirOverride
+	} else if dirFromEnv, ok := os.LookupEnv("ASTARTE_CONFIG_DIR"); ok && dirFromEnv != "" {
+		configDir = dirFromEnv
+	}
+	return configDir
+}
+
 // GetDefaultConfigDir returns the default config directory
 func GetDefaultConfigDir() string {
 	// TODO: In the future, we might want to have proper system vs. local configuration, but
@@ -94,14 +100,14 @@ func GetDefaultConfigDir() string {
 
 func clustersDirFromConfigDir(configDir string) string {
 	if configDir == "" {
-		configDir = GetDefaultConfigDir()
+		configDir = GetConfigDir()
 	}
 	return path.Join(configDir, "clusters")
 }
 
 func contextsDirFromConfigDir(configDir string) string {
 	if configDir == "" {
-		configDir = GetDefaultConfigDir()
+		configDir = GetConfigDir()
 	}
 	return path.Join(configDir, "contexts")
 }

--- a/config/utils.go
+++ b/config/utils.go
@@ -143,9 +143,9 @@ func listYamlNames(dirName string) ([]string, error) {
 
 func loadYamlFile(dirName, fileName string) ([]byte, error) {
 	yamlFileName := ""
-	if _, err := os.Stat(path.Join(dirName, fileName+".yaml")); err != nil {
+	if _, err := os.Stat(path.Join(dirName, fileName+".yaml")); err == nil {
 		yamlFileName = path.Join(dirName, fileName+".yaml")
-	} else if _, err := os.Stat(path.Join(dirName, fileName+".yml")); err != nil {
+	} else if _, err := os.Stat(path.Join(dirName, fileName+".yml")); err == nil {
 		yamlFileName = path.Join(dirName, fileName+".yml")
 	} else {
 		return nil, os.ErrNotExist

--- a/config/utils.go
+++ b/config/utils.go
@@ -57,9 +57,13 @@ func ConfigureViper(contextOverride string) error {
 	}
 
 	// Load the current context
-	viper.SetConfigName(currentContext)
-	viper.AddConfigPath(contextsDirFromConfigDir(configDir))
-	if err := viper.ReadInConfig(); err != nil {
+	contextViper := viper.New()
+	contextViper.SetConfigName(currentContext)
+	contextViper.AddConfigPath(contextsDirFromConfigDir(configDir))
+	if err := contextViper.ReadInConfig(); err != nil {
+		return err
+	}
+	if err := viper.MergeConfigMap(contextViper.AllSettings()); err != nil {
 		return err
 	}
 
@@ -70,14 +74,15 @@ func ConfigureViper(contextOverride string) error {
 	}
 
 	// Load the corresponding cluster
-	viper.SetConfigName(cluster)
-	viper.AddConfigPath(clustersDirFromConfigDir(configDir))
-	if err := viper.ReadInConfig(); err != nil {
+	clusterViper := viper.New()
+	clusterViper.SetConfigName(cluster)
+	clusterViper.AddConfigPath(clustersDirFromConfigDir(configDir))
+	if err := clusterViper.ReadInConfig(); err != nil {
 		return err
 	}
 
 	// Done loading
-	return nil
+	return viper.MergeConfigMap(clusterViper.AllSettings())
 }
 
 // GetConfigDir returns the Config Dir based on the current status

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/astarte-platform/astarte-go v0.0.0-20200326130039-e71af3170c16
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-openapi/strfmt v0.19.3 // indirect
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/uuid v1.1.1


### PR DESCRIPTION
Follow up on #80 . This integrates contexts in existing commands where it makes sense (most notably `cluster` and `housekeeping`), and adds a way to fetch an existing cluster configuration as a context.

This of course also fixes a variety of bugs and errors which went undetected in the previous PR.