### PR TITLE
Add new config subcommand

### DIFF
--- a/cmd/cluster/instance_get_cluster_config.go
+++ b/cmd/cluster/instance_get_cluster_config.go
@@ -87,7 +87,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 
 	configDir := config.GetConfigDir()
 
-	if err := config.SaveClusterConfiguration(configDir, clusterName, clusterConfig); err != nil {
+	if err := config.SaveClusterConfiguration(configDir, clusterName, clusterConfig, true); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -98,7 +98,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 	contextConfig := config.ContextFile{
 		Cluster: clusterName,
 	}
-	if err := config.SaveContextConfiguration(configDir, contextName, contextConfig); err != nil {
+	if err := config.SaveContextConfiguration(configDir, contextName, contextConfig, true); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/cmd/config/clusters.go
+++ b/cmd/config/clusters.go
@@ -1,0 +1,372 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"text/tabwriter"
+
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/spf13/cobra"
+)
+
+var clustersCmd = &cobra.Command{
+	Use:     "clusters",
+	Short:   "Manage clusters",
+	Long:    `List, show or create clusters in your astartectl configuration.`,
+	Aliases: []string{"cluster"},
+}
+
+var clustersListCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "List clusters",
+	Long:    "List clusters present in your astartectl configuration.",
+	Example: `  astartectl config clusters list`,
+	RunE:    clustersListF,
+	Aliases: []string{"ls"},
+}
+
+var clustersShowCmd = &cobra.Command{
+	Use:     "show <cluster_name>",
+	Short:   "Show cluster",
+	Long:    "Show a cluster in your astartectl configuration.",
+	Example: `  astartectl config clusters show mycluster`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    clustersShowF,
+}
+
+var clustersGetHousekeepingKeyCmd = &cobra.Command{
+	Use:     "get-housekeeping-key <cluster_name>",
+	Short:   "Get the Housekeeping key from a cluster",
+	Long:    "Get the Housekeeping key from a cluster in your astartectl configuration. This will work only if a housekeeping key is set",
+	Example: `  astartectl config clusters get-housekeeping-key mycluster`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    clustersGetHousekeepingKeyF,
+}
+
+var clustersCreateCmd = &cobra.Command{
+	Use:     "create <cluster_name>",
+	Short:   "Create cluster",
+	Long:    "Create a cluster in your astartectl configuration.",
+	Example: `  astartectl config clusters create mycluster --api-url https://my.astarte.apis.example.com --housekeeping-key /path/to/private_key`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    clustersCreateF,
+}
+
+var clustersUpdateCmd = &cobra.Command{
+	Use:     "update <cluster_name>",
+	Short:   "Update cluster",
+	Long:    "Update a cluster in your astartectl configuration.",
+	Example: `  astartectl config clusters update mycluster --api-url https://my.astarte.apis.example.com`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    clustersUpdateF,
+}
+
+var clustersDeleteCmd = &cobra.Command{
+	Use:     "delete <cluster_name>",
+	Short:   "Delete cluster",
+	Long:    "Delete a cluster in your Astarte instance.",
+	Example: `  astartectl config clusters delete mycluster`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    clustersDeleteF,
+	Aliases: []string{"del"},
+}
+
+func init() {
+	ConfigCmd.AddCommand(clustersCmd)
+
+	clustersGetHousekeepingKeyCmd.Flags().StringP("output", "o", "", "If specified, housekeeping key will be saved to specified file")
+
+	clustersCreateCmd.Flags().StringP("housekeeping-key", "k", "", "Path to PEM encoded private key used as housekeeping key")
+	if err := clustersCreateCmd.MarkFlagFilename("housekeeping-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	// TODO: Define the -t shorthand once we fix all the token everywhere mess
+	clustersCreateCmd.Flags().String("housekeeping-token", "", "A JWT token used to authenticate against housekeeping. To be provided if key is not available")
+	// TODO: Define the -u shorthand once we fix all the url everywhere mess
+	clustersCreateCmd.Flags().String("api-url", "", "The base API URL for the Astarte Cluster")
+	clustersCreateCmd.Flags().String("appengine-url", "", "The Appengine API URL for the Astarte Cluster")
+	clustersCreateCmd.Flags().String("flow-url", "", "The Flow API URL for the Astarte Cluster")
+	clustersCreateCmd.Flags().String("housekeeping-url", "", "The Housekeeping API URL for the Astarte Cluster")
+	clustersCreateCmd.Flags().String("pairing-url", "", "The Pairing API URL for the Astarte Cluster")
+	clustersCreateCmd.Flags().String("realm-management-url", "", "The Realm Management API URL for the Astarte Cluster")
+
+	clustersUpdateCmd.Flags().StringP("housekeeping-key", "k", "", "Path to PEM encoded private key used as housekeeping key")
+	if err := clustersUpdateCmd.MarkFlagFilename("housekeeping-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	// TODO: Define the -t shorthand once we fix all the token everywhere mess
+	clustersUpdateCmd.Flags().String("housekeeping-token", "", "A JWT token used to authenticate against housekeeping. To be provided if key is not available")
+	// TODO: Define the -u shorthand once we fix all the url everywhere mess
+	clustersUpdateCmd.Flags().String("api-url", "", "The base API URL for the Astarte Cluster")
+	clustersUpdateCmd.Flags().String("appengine-url", "", "The Appengine API URL for the Astarte Cluster")
+	clustersUpdateCmd.Flags().String("flow-url", "", "The Flow API URL for the Astarte Cluster")
+	clustersUpdateCmd.Flags().String("housekeeping-url", "", "The Housekeeping API URL for the Astarte Cluster")
+	clustersUpdateCmd.Flags().String("pairing-url", "", "The Pairing API URL for the Astarte Cluster")
+	clustersUpdateCmd.Flags().String("realm-management-url", "", "The Realm Management API URL for the Astarte Cluster")
+
+	clustersCmd.AddCommand(
+		clustersListCmd,
+		clustersShowCmd,
+		clustersGetHousekeepingKeyCmd,
+		clustersCreateCmd,
+		clustersUpdateCmd,
+		clustersDeleteCmd,
+	)
+}
+
+func clustersListF(command *cobra.Command, args []string) error {
+	configDir := config.GetConfigDir()
+	clusters, err := config.ListClusterConfigurations(configDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', tabwriter.DiscardEmptyColumns)
+	// header
+	fmt.Fprintln(w, "CLUSTER NAME\tAPI URL(S)")
+	for _, c := range clusters {
+		cluster, err := config.LoadClusterConfiguration(configDir, c)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(w, "%s\t", c)
+		if cluster.URL != "" {
+			fmt.Fprintln(w, cluster.URL)
+		} else {
+			fmt.Fprintf(w, "Appengine: %s\n", cluster.IndividualURLs.AppEngine)
+			fmt.Fprintf(w, "\tFlow: %s\n", cluster.IndividualURLs.Flow)
+			fmt.Fprintf(w, "\tHousekeeping: %s\n", cluster.IndividualURLs.Housekeeping)
+			fmt.Fprintf(w, "\tPairing: %s\n", cluster.IndividualURLs.Pairing)
+			fmt.Fprintf(w, "\tRealm Management: %s\n", cluster.IndividualURLs.RealmManagement)
+		}
+	}
+
+	w.Flush()
+	return nil
+}
+
+func clustersShowF(command *cobra.Command, args []string) error {
+	clusterName := args[0]
+
+	cluster, err := config.LoadClusterConfiguration(config.GetConfigDir(), clusterName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	if cluster.URL != "" {
+		fmt.Fprintf(w, "Astarte API URL:\t%s\n", cluster.URL)
+	} else {
+		fmt.Fprintf(w, "Astarte Individual API URLs:\t")
+		fmt.Fprintf(w, "Appengine: %s\n", cluster.IndividualURLs.AppEngine)
+		fmt.Fprintf(w, "\tFlow: %s\n", cluster.IndividualURLs.Flow)
+		fmt.Fprintf(w, "\tHousekeeping: %s\n", cluster.IndividualURLs.Housekeeping)
+		fmt.Fprintf(w, "\tPairing: %s\n", cluster.IndividualURLs.Pairing)
+		fmt.Fprintf(w, "\tRealm Management: %s\n", cluster.IndividualURLs.RealmManagement)
+	}
+	switch {
+	case cluster.Housekeeping.Key != "":
+		fmt.Fprintln(w, "Housekeeping Authentication:\tKey")
+	case cluster.Housekeeping.Token != "":
+		fmt.Fprintln(w, "Housekeeping Authentication:\tToken")
+	default:
+		fmt.Fprintln(w, "Housekeeping Authentication:\tNone")
+	}
+	w.Flush()
+
+	return nil
+}
+
+func clustersGetHousekeepingKeyF(command *cobra.Command, args []string) error {
+	clusterName := args[0]
+	output, err := command.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	cluster, err := config.LoadClusterConfiguration(config.GetConfigDir(), clusterName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if cluster.Housekeeping.Key == "" {
+		fmt.Fprintf(os.Stderr, "Cluster %s has no Housekeeping Key associated\n", clusterName)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(cluster.Housekeeping.Key)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if output != "" {
+		// Save to file
+		if err := ioutil.WriteFile(output, decoded, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else {
+		// Just throw it to stdout
+		fmt.Println(string(decoded))
+	}
+
+	return nil
+}
+
+func clustersCreateF(command *cobra.Command, args []string) error {
+	return performClusterCreation(args[0], false, command, args)
+}
+
+func clustersUpdateF(command *cobra.Command, args []string) error {
+	return performClusterCreation(args[0], true, command, args)
+}
+
+func clustersDeleteF(command *cobra.Command, args []string) error {
+	clusterName := args[0]
+
+	if _, err := config.LoadClusterConfiguration(config.GetConfigDir(), clusterName); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if ok, err := utils.AskForConfirmation(fmt.Sprintf("Will delete cluster %s. Are you sure you want to continue?", clusterName)); !ok || err != nil {
+		return nil
+	}
+
+	if err := config.DeleteClusterConfiguration(config.GetConfigDir(), clusterName); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Cluster %s deleted successfully\n", clusterName)
+	return nil
+}
+
+func performClusterCreation(clusterName string, isUpdate bool, command *cobra.Command, args []string) error {
+	configDir := config.GetConfigDir()
+	housekeepingKey, err := command.Flags().GetString("housekeeping-key")
+	if err != nil {
+		return err
+	}
+	housekeepingToken, err := command.Flags().GetString("housekeeping-token")
+	if err != nil {
+		return err
+	}
+	apiURL, err := command.Flags().GetString("api-url")
+	if err != nil {
+		return err
+	}
+	appengineURL, err := command.Flags().GetString("appengine-url")
+	if err != nil {
+		return err
+	}
+	flowURL, err := command.Flags().GetString("flow-url")
+	if err != nil {
+		return err
+	}
+	housekeepingURL, err := command.Flags().GetString("housekeeping-url")
+	if err != nil {
+		return err
+	}
+	pairingURL, err := command.Flags().GetString("pairing-url")
+	if err != nil {
+		return err
+	}
+	realmManagementURL, err := command.Flags().GetString("realm-management-url")
+	if err != nil {
+		return err
+	}
+
+	individualURLsSpecified := appengineURL != "" || flowURL != "" || housekeepingURL != "" || pairingURL != "" || realmManagementURL != ""
+
+	// Sanity checks
+	switch {
+	case apiURL != "" && individualURLsSpecified:
+		fmt.Fprintln(os.Stderr, "You cannot specify both --api-url and individual URLs")
+		os.Exit(1)
+	case apiURL == "" && !individualURLsSpecified && !isUpdate:
+		fmt.Fprintln(os.Stderr, "You should either specify --api-url or any number of individual URLs")
+		os.Exit(1)
+	case housekeepingKey != "" && housekeepingToken != "":
+		fmt.Fprintln(os.Stderr, "You should specify only one among --housekeeping-key and --housekeeping-token")
+		os.Exit(1)
+	}
+
+	// Check on the cluster
+	cluster, err := config.LoadClusterConfiguration(configDir, clusterName)
+	switch {
+	case err != nil && isUpdate:
+		fmt.Fprintf(os.Stderr, "Cluster %s does not exist. Maybe you meant to use create?\n", clusterName)
+		os.Exit(1)
+	case err == nil && !isUpdate:
+		fmt.Fprintf(os.Stderr, "A cluster named %s already exists. Maybe you meant to use update?\n", clusterName)
+		os.Exit(1)
+	}
+
+	// Go
+	if apiURL != "" {
+		cluster.URL = apiURL
+	}
+	if individualURLsSpecified {
+		if appengineURL != "" {
+			cluster.IndividualURLs.AppEngine = appengineURL
+		}
+		if flowURL != "" {
+			cluster.IndividualURLs.Flow = flowURL
+		}
+		if housekeepingURL != "" {
+			cluster.IndividualURLs.Housekeeping = housekeepingURL
+		}
+		if pairingURL != "" {
+			cluster.IndividualURLs.Pairing = pairingURL
+		}
+		if realmManagementURL != "" {
+			cluster.IndividualURLs.RealmManagement = realmManagementURL
+		}
+	}
+	if housekeepingKey != "" {
+		contents, err := ioutil.ReadFile(housekeepingKey)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		cluster.Housekeeping.Key = base64.StdEncoding.EncodeToString(contents)
+		cluster.Housekeeping.Token = ""
+	}
+	if housekeepingToken != "" {
+		cluster.Housekeeping.Token = housekeepingToken
+		cluster.Housekeeping.Key = ""
+	}
+
+	// Save
+	if err := config.SaveClusterConfiguration(configDir, clusterName, cluster, true); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Cluster %s saved successfully\n", clusterName)
+	return nil
+}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,35 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ConfigCmd represents the config command
+var ConfigCmd = &cobra.Command{
+	Use:               "config",
+	Short:             "Manage local astartectl configuration",
+	Long:              `Manage local astartectl configuration.`,
+	PersistentPreRunE: configPersistentPreRunE,
+}
+
+func init() {
+	// No additional vars
+}
+
+func configPersistentPreRunE(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/config/contexts.go
+++ b/cmd/config/contexts.go
@@ -1,0 +1,356 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"text/tabwriter"
+
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/astarte-platform/astartectl/utils"
+	"github.com/spf13/cobra"
+)
+
+var contextsCmd = &cobra.Command{
+	Use:     "contexts",
+	Short:   "Manage contexts",
+	Long:    `List, show or create contexts in your astartectl configuration.`,
+	Aliases: []string{"context"},
+}
+
+var contextsListCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "List contexts",
+	Long:    "List contexts present in your astartectl configuration.",
+	Example: `  astartectl config contexts list`,
+	RunE:    contextsListF,
+	Aliases: []string{"ls"},
+}
+
+var contextsShowCmd = &cobra.Command{
+	Use:     "show <context_name>",
+	Short:   "Show context",
+	Long:    "Show a context in your astartectl configuration.",
+	Example: `  astartectl config contexts show mycontext`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    contextsShowF,
+}
+
+var contextsGetRealmKeyCmd = &cobra.Command{
+	Use:     "get-realm-key <context_name>",
+	Short:   "Get the Realm key from a context",
+	Long:    "Get the Realm key from a context in your astartectl configuration. This will work only if a realm key is set",
+	Example: `  astartectl config contexts get-realm-key mycontext`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    contextsGetRealmKeyF,
+}
+
+var contextsCreateCmd = &cobra.Command{
+	Use:     "create <context_name>",
+	Short:   "Create context",
+	Long:    "Create a context in your astartectl configuration.",
+	Example: `  astartectl config contexts create mycontext --cluster mycluster --realm-name myrealm --realm-key /path/to/private_key`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    contextsCreateF,
+}
+
+var contextsUpdateCmd = &cobra.Command{
+	Use:     "update <context_name>",
+	Short:   "Update context",
+	Long:    "Update a context in your astartectl configuration.",
+	Example: `  astartectl config contexts update mycontext --realm-key /path/to/private_key`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    contextsUpdateF,
+}
+
+var contextsDeleteCmd = &cobra.Command{
+	Use:     "delete <context_name>",
+	Short:   "Delete context",
+	Long:    "Delete a context in your Astarte instance.",
+	Example: `  astartectl config contexts delete mycontext`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    contextsDeleteF,
+	Aliases: []string{"del"},
+}
+
+func init() {
+	ConfigCmd.AddCommand(contextsCmd)
+
+	contextsGetRealmKeyCmd.Flags().StringP("output", "o", "", "If specified, private key will be saved to specified file")
+
+	contextsCreateCmd.Flags().StringP("realm-private-key", "k", "", "Path to PEM encoded private key used as realm key")
+	if err := contextsCreateCmd.MarkFlagFilename("realm-private-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	contextsCreateCmd.Flags().StringP("realm-name", "r", "", "Realm name to which the context should be associated to")
+	// TODO: Define the -t shorthand once we fix all the token everywhere mess
+	contextsCreateCmd.Flags().String("realm-token", "", "A JWT token used to authenticate against the realm. To be provided if key is not available")
+	contextsCreateCmd.Flags().StringP("cluster", "c", "", "The cluster name the context should refer to. Must be an existing astartectl cluster")
+	if err := contextsCreateCmd.MarkFlagRequired("cluster"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	contextsCreateCmd.Flags().BoolP("activate", "a", false, "When specified, activates the context upon its creation")
+
+	contextsUpdateCmd.Flags().StringP("realm-private-key", "k", "", "Path to PEM encoded private key used as realm key")
+	if err := contextsUpdateCmd.MarkFlagFilename("realm-private-key"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	contextsUpdateCmd.Flags().StringP("realm-name", "r", "", "Realm name to which the context should be associated to")
+	// TODO: Define the -t shorthand once we fix all the token everywhere mess
+	contextsUpdateCmd.Flags().String("realm-token", "", "A JWT token used to authenticate against the realm. To be provided if key is not available")
+	contextsUpdateCmd.Flags().StringP("cluster", "c", "", "The cluster name the context should refer to. Must be an existing astartectl cluster")
+	contextsUpdateCmd.Flags().BoolP("activate", "a", false, "When specified, activates the context after updating it")
+
+	contextsCmd.AddCommand(
+		contextsListCmd,
+		contextsShowCmd,
+		contextsGetRealmKeyCmd,
+		contextsCreateCmd,
+		contextsUpdateCmd,
+		contextsDeleteCmd,
+	)
+}
+
+func contextsListF(command *cobra.Command, args []string) error {
+	configDir := config.GetConfigDir()
+	contexts, err := config.ListContextConfigurations(configDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	baseConfig, err := config.LoadBaseConfiguration(config.GetConfigDir())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', tabwriter.DiscardEmptyColumns)
+	// header
+	fmt.Fprintln(w, "CONTEXT NAME\tCLUSTER\tREALM NAME")
+	for _, c := range contexts {
+		context, err := config.LoadContextConfiguration(configDir, c)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		if baseConfig.CurrentContext == c {
+			fmt.Fprint(w, "* ")
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", c, context.Cluster, context.Realm.Name)
+	}
+
+	w.Flush()
+	return nil
+}
+
+func contextsShowF(command *cobra.Command, args []string) error {
+	contextName := args[0]
+
+	context, err := config.LoadContextConfiguration(config.GetConfigDir(), contextName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
+	fmt.Fprintf(w, "Cluster name:\t%s\n", context.Cluster)
+
+	cluster, err := config.LoadClusterConfiguration(config.GetConfigDir(), context.Cluster)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if context.Realm.Name != "" {
+		fmt.Fprintf(w, "Astarte Realm:\t%s\n", context.Realm.Name)
+		switch {
+		case context.Realm.Key != "":
+			fmt.Fprintln(w, "Realm Authentication:\tKey")
+		case context.Realm.Token != "":
+			fmt.Fprintln(w, "Realm Authentication:\tToken")
+		default:
+			fmt.Fprintln(w, "Realm Authentication:\tNone")
+		}
+	}
+	if cluster.URL != "" {
+		fmt.Fprintf(w, "Astarte API URL:\t%s\n", cluster.URL)
+	} else {
+		fmt.Fprintln(w, "Cluster API URL Type:\tindividual")
+	}
+	w.Flush()
+
+	return nil
+}
+
+func contextsGetRealmKeyF(command *cobra.Command, args []string) error {
+	contextName := args[0]
+	output, err := command.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	context, err := config.LoadContextConfiguration(config.GetConfigDir(), contextName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if context.Realm.Key == "" {
+		fmt.Fprintf(os.Stderr, "Context %s has no Realm Key associated\n", contextName)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(context.Realm.Key)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if output != "" {
+		// Save to file
+		if err := ioutil.WriteFile(output, decoded, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else {
+		// Just throw it to stdout
+		fmt.Println(string(decoded))
+	}
+
+	return nil
+}
+
+func contextsCreateF(command *cobra.Command, args []string) error {
+	return performContextCreation(args[0], false, command, args)
+}
+
+func contextsUpdateF(command *cobra.Command, args []string) error {
+	return performContextCreation(args[0], true, command, args)
+}
+
+func contextsDeleteF(command *cobra.Command, args []string) error {
+	contextName := args[0]
+
+	if _, err := config.LoadContextConfiguration(config.GetConfigDir(), contextName); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if ok, err := utils.AskForConfirmation(fmt.Sprintf("Will delete context %s. Are you sure you want to continue?", contextName)); !ok || err != nil {
+		return nil
+	}
+
+	if err := config.DeleteContextConfiguration(config.GetConfigDir(), contextName); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Context %s deleted successfully\n", contextName)
+	return nil
+}
+
+func performContextCreation(contextName string, isUpdate bool, command *cobra.Command, args []string) error {
+	configDir := config.GetConfigDir()
+	realmName, err := command.Flags().GetString("realm-name")
+	if err != nil {
+		return err
+	}
+	realmPrivateKey, err := command.Flags().GetString("realm-private-key")
+	if err != nil {
+		return err
+	}
+	realmToken, err := command.Flags().GetString("realm-token")
+	if err != nil {
+		return err
+	}
+	clusterName, err := command.Flags().GetString("cluster")
+	if err != nil {
+		return err
+	}
+	activate, err := command.Flags().GetBool("activate")
+	if err != nil {
+		return err
+	}
+
+	// Sanity checks
+	switch {
+	case (realmPrivateKey != "" || realmToken != "") && realmName == "" && !isUpdate:
+		fmt.Fprintln(os.Stderr, "When specifying Realm authentication credentials, you should specify --realm-name")
+		os.Exit(1)
+	case realmPrivateKey != "" && realmToken != "":
+		fmt.Fprintln(os.Stderr, "You should specify only one among --realm-key and --realm-token")
+		os.Exit(1)
+	}
+
+	if _, err := config.LoadClusterConfiguration(configDir, clusterName); err != nil && clusterName != "" {
+		fmt.Fprintf(os.Stderr, "Cluster %s does not exist\n", clusterName)
+		os.Exit(1)
+	}
+
+	// Check on the context
+	context, err := config.LoadContextConfiguration(configDir, contextName)
+	switch {
+	case err != nil && isUpdate:
+		fmt.Fprintf(os.Stderr, "Context %s does not exist. Maybe you meant to use create?\n", contextName)
+		os.Exit(1)
+	case err == nil && !isUpdate:
+		fmt.Fprintf(os.Stderr, "A context named %s already exists. Maybe you meant to use update?\n", contextName)
+		os.Exit(1)
+	}
+
+	// Go
+	if clusterName != "" {
+		context.Cluster = clusterName
+	}
+	if realmName != "" {
+		context.Realm.Name = realmName
+	}
+	if realmPrivateKey != "" {
+		contents, err := ioutil.ReadFile(realmPrivateKey)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		context.Realm.Key = base64.StdEncoding.EncodeToString(contents)
+		context.Realm.Token = ""
+	}
+	if realmToken != "" {
+		context.Realm.Token = realmToken
+		context.Realm.Key = ""
+	}
+
+	// Save
+	if err := config.SaveContextConfiguration(configDir, contextName, context, true); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Context %s saved successfully\n", contextName)
+
+	if activate {
+		if err := updateCurrentContext(contextName); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Context switched to %s\n", contextName)
+		return nil
+	}
+
+	return nil
+}

--- a/cmd/config/current.go
+++ b/cmd/config/current.go
@@ -1,0 +1,82 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/spf13/cobra"
+)
+
+var currentContextCmd = &cobra.Command{
+	Use:     "current-context",
+	Short:   "Shows the current astartectl configuration context",
+	Long:    `Shows the current astartectl configuration context.`,
+	Args:    cobra.ExactArgs(0),
+	RunE:    currentContextF,
+	Aliases: []string{"get-current-context"},
+}
+
+var setCurrentContextCmd = &cobra.Command{
+	Use:     "set-current-context <context>",
+	Short:   "Sets the current astartectl configuration context",
+	Long:    `Sets the current astartectl configuration context`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    setCurrentContextF,
+	Aliases: []string{"use-context"},
+}
+
+func init() {
+	ConfigCmd.AddCommand(currentContextCmd)
+	ConfigCmd.AddCommand(setCurrentContextCmd)
+}
+
+func currentContextF(command *cobra.Command, args []string) error {
+	baseConfig, err := config.LoadBaseConfiguration(config.GetConfigDir())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Println(baseConfig.CurrentContext)
+	return nil
+}
+
+func setCurrentContextF(command *cobra.Command, args []string) error {
+	if err := updateCurrentContext(args[0]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Context switched to %s\n", args[0])
+	return nil
+}
+
+func updateCurrentContext(newCurrentContext string) error {
+	configDir := config.GetConfigDir()
+	baseConfig, err := config.LoadBaseConfiguration(configDir)
+	if err != nil {
+		return err
+	}
+	if _, err := config.LoadContextConfiguration(configDir, newCurrentContext); err != nil {
+		return err
+	}
+
+	baseConfig.CurrentContext = newCurrentContext
+
+	return config.SaveBaseConfiguration(configDir, baseConfig)
+}

--- a/cmd/config/import_export.go
+++ b/cmd/config/import_export.go
@@ -1,0 +1,139 @@
+// Copyright © 2020 Ispirata Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/astarte-platform/astartectl/config"
+	"github.com/spf13/cobra"
+)
+
+var configImportCmd = &cobra.Command{
+	Use:   "import <config_file>",
+	Short: "Import configuration file",
+	Long: `Import a configuration file previously exported with astartectl. This might
+	be a partial export or a full export, and it should be in JSON format. By default, existing
+	clusters and context won't be overwritten - you can force this behavior with --overwrite.`,
+	Example: `  astartectl config import export.json`,
+	Args:    cobra.ExactArgs(1),
+	RunE:    configImportF,
+}
+
+var configExportCmd = &cobra.Command{
+	Use:   "export [-o <output_file>]",
+	Short: "Export current astartectl configuration",
+	Long: `Export current astartectl configuration to a JSON file, which can be later imported through
+	astartectl config import. By default, the complete list of clusters and contexts is exported, but you can
+	tweak this behavior by using --clusters and --contexts, providing a list of names. By default, the resulting
+	JSON file is printed on stdout, but it can also be saved to a file by specifying -o.`,
+	Example: `  astartectl housekeeping realms create myrealm -p /path/to/public_key`,
+	Args:    cobra.ExactArgs(0),
+	RunE:    configExportF,
+}
+
+func init() {
+	ConfigCmd.AddCommand(configImportCmd)
+	ConfigCmd.AddCommand(configExportCmd)
+
+	configImportCmd.Flags().Bool("overwrite", false, "When specified, overwrites existing clusters or contexts with matching filenames")
+	configImportCmd.Flags().StringSlice("clusters", []string{}, "A list of clusters to be imported, comma separated. If not specified, all clusters will be imported")
+	configImportCmd.Flags().StringSlice("contexts", []string{}, "A list of contexts to be imported, comma separated. If not specified, all contexts will be imported")
+
+	configExportCmd.Flags().StringP("output", "o", "", "If specified, configuration will be exported to specified file")
+	configExportCmd.Flags().StringSlice("clusters", []string{}, "A list of clusters to be exported, comma separated. If not specified, all clusters will be exported")
+	configExportCmd.Flags().StringSlice("contexts", []string{}, "A list of contexts to be exported, comma separated. If not specified, all contexts will be exported")
+}
+
+func configImportF(command *cobra.Command, args []string) error {
+	overwrite, err := command.Flags().GetBool("overwrite")
+	if err != nil {
+		return err
+	}
+	clusters, err := command.Flags().GetStringSlice("clusters")
+	if err != nil {
+		return err
+	}
+	contexts, err := command.Flags().GetStringSlice("contexts")
+	if err != nil {
+		return err
+	}
+
+	// First of all, read the file content
+	contents, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Load the bundle
+	var bundle config.Bundle
+	if err := json.Unmarshal(contents, &bundle); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Go for it
+	if err := config.LoadBundleToDirectory(bundle, config.GetConfigDir(), clusters, contexts, overwrite); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Configuration imported successfully.")
+	return nil
+}
+
+func configExportF(command *cobra.Command, args []string) error {
+	output, err := command.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	clusters, err := command.Flags().GetStringSlice("clusters")
+	if err != nil {
+		return err
+	}
+	contexts, err := command.Flags().GetStringSlice("contexts")
+	if err != nil {
+		return err
+	}
+
+	// Go for it
+	bundle, err := config.CreateBundleFromDirectory(config.GetConfigDir(), clusters, contexts)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Get some JSON out of it
+	jsonBytes, err := json.Marshal(bundle)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	if output == "" {
+		fmt.Println(string(jsonBytes))
+	} else {
+		if err := ioutil.WriteFile(output, jsonBytes, 0644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+
+	return nil
+}

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -308,7 +308,7 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	}
 
 	configDir := config.GetConfigDir()
-	if err := config.SaveContextConfiguration(configDir, contextName, configContext); err != nil {
+	if err := config.SaveContextConfiguration(configDir, contextName, configContext, true); err != nil {
 		fmt.Printf("Could not save cluster configuration: %s\n", err)
 		if privateKey == "" {
 			// Dump the private key

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/astarte-platform/astartectl/cmd/appengine"
 	"github.com/astarte-platform/astartectl/cmd/cluster"
+	configcmd "github.com/astarte-platform/astartectl/cmd/config"
 	"github.com/astarte-platform/astartectl/cmd/housekeeping"
 	"github.com/astarte-platform/astartectl/cmd/pairing"
 	"github.com/astarte-platform/astartectl/cmd/realm"
@@ -77,6 +78,7 @@ func init() {
 	rootCmd.AddCommand(utils.UtilsCmd)
 	rootCmd.AddCommand(appengine.AppEngineCmd)
 	rootCmd.AddCommand(cluster.ClusterCmd)
+	rootCmd.AddCommand(configcmd.ConfigCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/config/utils.go
+++ b/config/utils.go
@@ -146,14 +146,19 @@ func listYamlNames(dirName string) ([]string, error) {
 	return names, nil
 }
 
-func loadYamlFile(dirName, fileName string) ([]byte, error) {
-	yamlFileName := ""
+func getYamlFilename(dirName, fileName string) (string, error) {
 	if _, err := os.Stat(path.Join(dirName, fileName+".yaml")); err == nil {
-		yamlFileName = path.Join(dirName, fileName+".yaml")
+		return path.Join(dirName, fileName+".yaml"), nil
 	} else if _, err := os.Stat(path.Join(dirName, fileName+".yml")); err == nil {
-		yamlFileName = path.Join(dirName, fileName+".yml")
-	} else {
-		return nil, os.ErrNotExist
+		return path.Join(dirName, fileName+".yml"), nil
+	}
+	return "", os.ErrNotExist
+}
+
+func loadYamlFile(dirName, fileName string) ([]byte, error) {
+	yamlFileName, err := getYamlFilename(dirName, fileName)
+	if err != nil {
+		return nil, err
 	}
 
 	// Read file contents and return it


### PR DESCRIPTION
Adds the new config subcommand to astartectl. This allows manipulation of the entire configuration and contexts through astartectl itself. In particular, it introduces these new subcommands:

 * config import/export: To import or export configuration, either full or fine-grained
 * config {set-}current-context: kubectl-style, shows the current context
 * config contexts: Allows manipulation of configuration contexts
 * config clusters: Allows manipulation of configuration clusters

This is the last step of, and resolves, #80 