### PR TITLE
device: Ensure send-data parses integer correctly for aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+### Fixed
+- `appengine devices send-data` now parses integer values correctly for server-owned datastream aggregate
+  interfaces
+
 ## [0.11.0-rc.1] - 2020-04-01
 ### Added
 - Add `realm-management interfaces sync` subcommand

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -729,6 +730,19 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 		if err := json.Unmarshal([]byte(payloadData), &aggrPayload); err != nil {
 			return err
 		}
+
+		// The json module parses all numbers into float64. To ensure Astarte will validate our payloads
+		// correctly, we should convert to int every payload for which an integer conversion does not lose
+		// in precision
+		for k, v := range aggrPayload {
+			switch val := v.(type) {
+			case float64:
+				if val == math.Trunc(val) {
+					aggrPayload[k] = int(val)
+				}
+			}
+		}
+
 		parsedPayloadData = aggrPayload
 	}
 


### PR DESCRIPTION
Due to how JSON marshaling works in Go, all numbers are parsed as a float64. However, when dealing with Astarte type validation, this caused failures for integer values due to an inherent loss of precision upon conversion. Instead, if Math.trunc tells us we're not losing precision, cast values to int to ensure that the type will be validated (note that this works even if the integer is meant to represent a float, as there is no precision loss involved).