### PR TITLE
Various fixes in namespace handling in cluster

### DIFF
--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -91,6 +91,9 @@ func init() {
 		"(optional) absolute path to the kubeconfig file")
 	viper.BindPFlag("kubeconfig", ClusterCmd.PersistentFlags().Lookup("kubeconfig"))
 
+	// Add flags which are common to all instances commands
+	InstancesCmd.PersistentFlags().StringP("namespace", "n", "astarte", "Namespace of the Astarte resource. Defaults to 'astarte'")
+
 	ClusterCmd.AddCommand(InstancesCmd)
 }
 

--- a/cmd/cluster/instance_deploy.go
+++ b/cmd/cluster/instance_deploy.go
@@ -40,7 +40,6 @@ kubectl mentions. If no versions are specified, the last stable version is deplo
 
 func init() {
 	deployCmd.PersistentFlags().String("name", "", "Name of the deployed Astarte resource.")
-	deployCmd.PersistentFlags().String("namespace", "", "Namespace in which the Astarte resource will be deployed.")
 	deployCmd.PersistentFlags().String("version", "", "Version of Astarte to deploy. If not specified, last stable version will be deployed.")
 	deployCmd.PersistentFlags().String("profile", "", "Astarte Deployment Profile. If not specified, it will be prompted when deploying.")
 	deployCmd.PersistentFlags().String("api-host", "", "The API host for this Astarte deployment. If not specified, it will be prompted when deploying.")

--- a/cmd/cluster/instance_destroy.go
+++ b/cmd/cluster/instance_destroy.go
@@ -36,7 +36,6 @@ kubectl mentions. Please be aware of the fact that when an Astarte instance is d
 }
 
 func init() {
-	destroyCmd.PersistentFlags().String("namespace", "", "Namespace in which to look for the Astarte resource will be destroyed.")
 	destroyCmd.PersistentFlags().Bool("delete-volumes", false, "When set, all the Persistent Volume Claims will be destroyed. All data will be lost with no means of recovery.")
 	destroyCmd.PersistentFlags().BoolP("non-interactive", "y", false, "Non-interactive mode. Will answer yes by default to all questions.")
 

--- a/cmd/cluster/instance_fetch_housekeeping_key.go
+++ b/cmd/cluster/instance_fetch_housekeeping_key.go
@@ -31,7 +31,6 @@ var fetchHKPrivateKeyCmd = &cobra.Command{
 }
 
 func init() {
-	fetchHKPrivateKeyCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
 	fetchHKPrivateKeyCmd.PersistentFlags().StringP("output", "o", "", "When specified, saves the key to the specified file rather than printing it in stdout.")
 
 	InstancesCmd.AddCommand(fetchHKPrivateKeyCmd)

--- a/cmd/cluster/instance_get_cluster_config.go
+++ b/cmd/cluster/instance_get_cluster_config.go
@@ -36,8 +36,6 @@ will be created, together with a new context matching the cluster, without an as
 }
 
 func init() {
-	getClusterConfigCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
-
 	InstancesCmd.AddCommand(getClusterConfigCmd)
 }
 

--- a/cmd/cluster/instance_show.go
+++ b/cmd/cluster/instance_show.go
@@ -32,8 +32,6 @@ var instanceShowCmd = &cobra.Command{
 }
 
 func init() {
-	instanceShowCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
-
 	InstancesCmd.AddCommand(instanceShowCmd)
 }
 

--- a/cmd/cluster/instance_upgrade.go
+++ b/cmd/cluster/instance_upgrade.go
@@ -40,7 +40,6 @@ var instanceUpgradeCmd = &cobra.Command{
 }
 
 func init() {
-	instanceUpgradeCmd.PersistentFlags().String("namespace", "astarte", "Namespace in which to look for the Astarte resource.")
 	instanceUpgradeCmd.PersistentFlags().String("profile", "", "Astarte Deployment Profile. Ignored if the existing Astarte instance is already associated to a Profile. If not specified and not associated yet, it will be prompted when deploying.")
 	instanceUpgradeCmd.PersistentFlags().BoolP("non-interactive", "y", false, "Non-interactive mode. Will answer yes by default to all questions.")
 

--- a/cmd/cluster/show.go
+++ b/cmd/cluster/show.go
@@ -47,7 +47,7 @@ func clusterShowF(command *cobra.Command, args []string) error {
 	fmt.Printf("This Cluster is running Astarte Operator version %s.\n\n",
 		strings.Split(operator.Spec.Template.Spec.Containers[0].Image, ":")[1])
 
-	astartes, err := listAstartes()
+	astartes, err := listAstartes("")
 	if err != nil || len(astartes) == 0 {
 		fmt.Println("No Managed Astarte installations found. Maybe you want to deploy one with astartectl cluster instance deploy?")
 		return nil

--- a/cmd/cluster/uninstall_operator.go
+++ b/cmd/cluster/uninstall_operator.go
@@ -46,7 +46,7 @@ func clusterUninstallF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	astartes, err := listAstartes()
+	astartes, err := listAstartes("")
 	if err == nil && len(astartes) > 0 {
 		fmt.Println("Your cluster has at least one active Astarte instance managed by the Operator. You can uninstall the operator only if no instances are deployed.")
 		os.Exit(1)


### PR DESCRIPTION
This fixes a bug introduced over refactoring, and streamlines the --namespace option together with its -n shorthand.