### PR TITLE
data-snapshot: Don't fail if an interface fails parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `appengine devices send-data` now parses integer values correctly for server-owned datastream aggregate
   interfaces
+- `appengine devices data-snapshot` now handles partial failures in a better way without compromising the
+  full results
 
 ## [0.11.0-rc.1] - 2020-04-01
 ### Added

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -349,7 +349,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 				if i.IsParametric() {
 					val, err := astarteAPIClient.AppEngine.GetAggregateParametricDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
 					if err != nil {
-						return err
+						warnOrFail(snapshotInterface, i.Name, err)
 					}
 					for path, aggregate := range val {
 						if outputType == "json" {
@@ -373,7 +373,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 				} else {
 					val, err := astarteAPIClient.AppEngine.GetAggregateDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
 					if err != nil {
-						return err
+						warnOrFail(snapshotInterface, i.Name, err)
 					}
 					if outputType == "json" {
 						jsonOutput[i.Name] = val
@@ -396,7 +396,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 			} else {
 				val, err := astarteAPIClient.AppEngine.GetDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
 				if err != nil {
-					return err
+					warnOrFail(snapshotInterface, i.Name, err)
 				}
 				jsonRepresentation := make(map[string]interface{})
 				for k, v := range val {
@@ -417,7 +417,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 		case interfaces.PropertiesType:
 			val, err := astarteAPIClient.AppEngine.GetProperties(realm, deviceID, deviceIdentifierType, i.Name)
 			if err != nil {
-				return err
+				warnOrFail(snapshotInterface, i.Name, err)
 			}
 			jsonRepresentation := make(map[string]interface{})
 			for k, v := range val {
@@ -439,6 +439,17 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 	renderOutput(t, jsonOutput, outputType)
 
 	return nil
+}
+
+func warnOrFail(snapshotInterface, interfaceName string, err error) {
+	if snapshotInterface != "" {
+		// Fail only if we're parsing a single interface
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	// Just warn
+	fmt.Fprintf(os.Stderr, "warn: Could not parse results for interface %s: %s\n", interfaceName, err)
 }
 
 func devicesGetSamplesF(command *cobra.Command, args []string) error {


### PR DESCRIPTION
Given v1 is not as deterministic as we would like it to be, we have to assume parsing an interface result in a pretty way might indeed fail. In particular, data-snapshot should not give up in showing results if just partial failures occur.