### PR TITLE
Print errors and warnings to stderr

### DIFF
--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -163,7 +163,7 @@ func init() {
 func devicesListF(command *cobra.Command, args []string) error {
 	devices, err := astarteAPIClient.AppEngine.ListDevices(realm)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -237,7 +237,7 @@ func devicesShowF(command *cobra.Command, args []string) error {
 
 	deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -309,7 +309,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 
 		deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
 		if err != nil {
-			fmt.Println(err.Error())
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -328,7 +328,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 		// Get the proto interface
 		iface, err := getProtoInterface(deviceID, deviceIdentifierType, snapshotInterface, interfaceTypeString, skipRealmManagementChecks)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
@@ -528,7 +528,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 			}
 
 			if interfaceDescription.Type != interfaces.DatastreamType {
-				fmt.Printf("%s is not a Datastream interface. get-samples works only on Datastream interfaces\n", interfaceName)
+				fmt.Fprintf(os.Stderr, "%s is not a Datastream interface. get-samples works only on Datastream interfaces\n", interfaceName)
 				os.Exit(1)
 			}
 
@@ -537,21 +537,21 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 
 			switch {
 			case isAggregate && interfaceDescription.IsParametric() && interfacePath == "":
-				fmt.Printf("%s is an aggregate parametric interface, a valid path should be specified\n", interfaceName)
+				fmt.Fprintf(os.Stderr, "%s is an aggregate parametric interface, a valid path should be specified\n", interfaceName)
 				os.Exit(1)
 			case !isAggregate && interfacePath == "":
-				fmt.Printf("You need to specify a valid path for interface %s\n", interfaceName)
+				fmt.Fprintf(os.Stderr, "You need to specify a valid path for interface %s\n", interfaceName)
 				os.Exit(1)
 			default:
 				if err := interfaces.ValidateQuery(interfaceDescription, interfacePath); err != nil {
-					fmt.Println(err)
+					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
 				}
 			}
 		}
 
 		if !interfaceFound {
-			fmt.Printf("Device %s has no interface named %s\n", deviceID, interfaceName)
+			fmt.Fprintf(os.Stderr, "Device %s has no interface named %s\n", deviceID, interfaceName)
 			os.Exit(1)
 		}
 	} else {
@@ -568,13 +568,13 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 		datastreamPaginator, err := astarteAPIClient.AppEngine.GetDatastreamsTimeWindowPaginator(realm, deviceID,
 			deviceIdentifierType, interfaceName, interfacePath, sinceTime, toTime, resultSetOrder)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		for ok := true; ok; ok = datastreamPaginator.HasNextPage() {
 			page, err := datastreamPaginator.GetNextPage()
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 
@@ -601,13 +601,13 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 		datastreamPaginator, err := astarteAPIClient.AppEngine.GetDatastreamsTimeWindowPaginator(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath,
 			sinceTime, toTime, resultSetOrder)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		for ok := true; ok; ok = datastreamPaginator.HasNextPage() {
 			page, err := datastreamPaginator.GetNextAggregatePage()
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 
@@ -676,12 +676,12 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 
 	iface, err := getProtoInterface(deviceID, deviceIdentifierType, interfaceName, interfaceTypeString, skipRealmManagementChecks)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if !skipRealmManagementChecks {
 		if iface.Ownership != interfaces.ServerOwnership {
-			fmt.Println("send-data makes sense only for server-owned interfaces")
+			fmt.Fprintln(os.Stderr, "send-data makes sense only for server-owned interfaces")
 			os.Exit(1)
 		}
 	}
@@ -712,7 +712,7 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 		if payloadType == "" {
 			mapping, err := interfaces.InterfaceMappingFromPath(iface, interfacePath)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 			payloadType = mapping.Type
@@ -764,7 +764,7 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 	}
 
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/appengine/device_aliases.go
+++ b/cmd/appengine/device_aliases.go
@@ -73,12 +73,12 @@ func init() {
 func aliasesListF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	if !misc.IsValidAstarteDeviceID(deviceID) {
-		fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
+		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 	aliases, err := astarteAPIClient.AppEngine.ListDeviceAliases(realm, deviceID)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -89,19 +89,19 @@ func aliasesListF(command *cobra.Command, args []string) error {
 func aliasesAddF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	if !misc.IsValidAstarteDeviceID(deviceID) {
-		fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
+		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 	alias := args[1]
 	s := strings.Split(alias, "=")
 	if len(s) != 2 {
-		fmt.Println("Alias should be in the form <alias-tag>=<alias>")
+		fmt.Fprintf(os.Stderr, "Alias should be in the form <alias-tag>=<alias>")
 		os.Exit(1)
 	}
 
 	err := astarteAPIClient.AppEngine.AddDeviceAlias(realm, deviceID, s[0], s[1])
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -112,14 +112,14 @@ func aliasesAddF(command *cobra.Command, args []string) error {
 func aliasesRemoveF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	if !misc.IsValidAstarteDeviceID(deviceID) {
-		fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
+		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 	aliasTag := args[1]
 
 	err := astarteAPIClient.AppEngine.DeleteDeviceAlias(realm, deviceID, aliasTag)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/appengine/device_credentials.go
+++ b/cmd/appengine/device_credentials.go
@@ -73,7 +73,7 @@ func devicesCredentialsInhibitF(command *cobra.Command, args []string) error {
 
 	err = astarteAPIClient.AppEngine.InhibitDevice(realm, deviceID, deviceIdentifierType, inhibit)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/appengine/groups.go
+++ b/cmd/appengine/groups.go
@@ -112,7 +112,7 @@ func init() {
 func groupsListF(command *cobra.Command, args []string) error {
 	groupsList, err := astarteAPIClient.AppEngine.ListGroups(realm)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -140,7 +140,7 @@ func groupsCreateF(command *cobra.Command, args []string) error {
 	}
 	err = astarteAPIClient.AppEngine.CreateGroup(realm, groupName, deviceIdentifiers, deviceIdentifiersType)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -153,7 +153,7 @@ func groupsDevicesListF(command *cobra.Command, args []string) error {
 
 	deviceList, err := astarteAPIClient.AppEngine.ListGroupDevices(realm, groupName)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -177,7 +177,7 @@ func groupsDevicesAddF(command *cobra.Command, args []string) error {
 
 	err = astarteAPIClient.AppEngine.AddDeviceToGroup(realm, groupName, deviceIdentifier, deviceIdentifierType)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -201,7 +201,7 @@ func groupsDevicesRemoveF(command *cobra.Command, args []string) error {
 
 	err = astarteAPIClient.AppEngine.RemoveDeviceFromGroup(realm, groupName, deviceIdentifier, deviceIdentifierType)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/cluster/install_operator.go
+++ b/cmd/cluster/install_operator.go
@@ -65,26 +65,26 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 	if version == "" {
 		version, err = getLastOperatorRelease()
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
 
 	semVersion, err := semver.NewVersion(version)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	if isUnstableVersion(version) {
-		fmt.Println("You're trying install in your cluster an unstable snapshot - this is usually is a bad idea. Make sure you know what you're doing.")
+		fmt.Fprintln(os.Stderr, "You're trying install in your cluster an unstable snapshot - this is usually is a bad idea. Make sure you know what you're doing.")
 	}
 
 	fmt.Printf("Will install Astarte Operator version %s in the Cluster.\n", version)
 	if !nonInteractive {
 		confirmation, err := utils.AskForConfirmation("Do you want to continue?")
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		if !confirmation {
@@ -100,10 +100,10 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 		context.TODO(), serviceAccount.(*corev1.ServiceAccount), metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			fmt.Println("WARNING: Service Account already exists in the cluster.")
+			fmt.Fprintln(os.Stderr, "WARNING: Service Account already exists in the cluster.")
 		} else {
-			fmt.Println("Error while deploying Service Account. Your deployment might be incomplete.")
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, "Error while deploying Service Account. Your deployment might be incomplete.")
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -113,10 +113,10 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 	_, err = kubernetesClient.RbacV1().ClusterRoles().Create(context.TODO(), role.(*rbacv1.ClusterRole), metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			fmt.Println("WARNING: Cluster Role already exists in the cluster.")
+			fmt.Fprintln(os.Stderr, "WARNING: Cluster Role already exists in the cluster.")
 		} else {
-			fmt.Println("Error while deploying Service Account. Your deployment might be incomplete.")
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, "Error while deploying Service Account. Your deployment might be incomplete.")
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -127,10 +127,10 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 		context.TODO(), roleBinding.(*rbacv1.ClusterRoleBinding), metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			fmt.Println("WARNING: Cluster Role Binding already exists in the cluster.")
+			fmt.Fprintln(os.Stderr, "WARNING: Cluster Role Binding already exists in the cluster.")
 		} else {
-			fmt.Println("Error while deploying Service Account. Your deployment might be incomplete.")
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, "Error while deploying Service Account. Your deployment might be incomplete.")
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -152,10 +152,10 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 		context.TODO(), astarteCRD.(*apiextensionsv1beta1.CustomResourceDefinition), metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			fmt.Println("WARNING: Astarte CRD already exists in the cluster.")
+			fmt.Fprintln(os.Stderr, "WARNING: Astarte CRD already exists in the cluster.")
 		} else {
-			fmt.Println("Error while deploying Astarte CRD. Your deployment might be incomplete.")
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, "Error while deploying Astarte CRD. Your deployment might be incomplete.")
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -165,10 +165,10 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 		context.TODO(), astarteVoyagerIngressCRD.(*apiextensionsv1beta1.CustomResourceDefinition), metav1.CreateOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			fmt.Println("WARNING: AstarteVoyagerIngress CRD already exists in the cluster.")
+			fmt.Fprintln(os.Stderr, "WARNING: AstarteVoyagerIngress CRD already exists in the cluster.")
 		} else {
-			fmt.Println("Error while deploying AstarteVoyagerIngress CRD. Your deployment might be incomplete.")
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, "Error while deploying AstarteVoyagerIngress CRD. Your deployment might be incomplete.")
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -181,8 +181,8 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 	astarteOperatorDeployment, err := kubernetesClient.AppsV1().Deployments("kube-system").Create(
 		context.TODO(), astarteOperator.(*appsv1.Deployment), metav1.CreateOptions{})
 	if err != nil {
-		fmt.Println("Error while deploying Astarte Operator Deployment. Your deployment might be incomplete.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Error while deploying Astarte Operator Deployment. Your deployment might be incomplete.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -192,8 +192,8 @@ func clusterInstallF(command *cobra.Command, args []string) error {
 	watcher, err := kubernetesClient.AppsV1().Deployments("kube-system").Watch(
 		context.TODO(), metav1.ListOptions{TimeoutSeconds: &timeoutSeconds})
 	if err != nil {
-		fmt.Println("Could not watch the Deployment state. However, deployment might be complete. Check with astartectl cluster show in a while.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Could not watch the Deployment state. However, deployment might be complete. Check with astartectl cluster show in a while.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	ch := watcher.ResultChan()

--- a/cmd/cluster/instance_change_profile.go
+++ b/cmd/cluster/instance_change_profile.go
@@ -50,7 +50,7 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -59,7 +59,7 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 
 	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
 	if err != nil {
-		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
+		fmt.Fprintf(os.Stderr, "Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
 		os.Exit(1)
 	}
 
@@ -67,12 +67,12 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 	_, deploymentManager, deploymentProfile := getManagedAstarteResourceStatus(*astarteObject)
 	oldAstarteVersion, err := semver.NewVersion(astarteSpec["version"].(string))
 	if err != nil {
-		fmt.Printf("Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
+		fmt.Fprintf(os.Stderr, "Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
 		os.Exit(1)
 	}
 
 	if deploymentManager != "astartectl" {
-		fmt.Println("WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
+		fmt.Fprintf(os.Stderr, "WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
 	}
 
 	newProfile := ""
@@ -94,7 +94,7 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 		// Get the profile
 		newProfile, astarteDeployment, err = promptForProfileExcluding(command, oldAstarteVersion, []string{deploymentProfile})
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	} else {
@@ -111,7 +111,7 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 			newProfile, astarteDeployment, astarteSpec)
 	} else {
 		// Fail.
-		fmt.Printf("I found no matching '%s' profile for Astarte %s. Maybe you spelled the profile wrong, or you should upgrade astartectl first?\n", newProfile, oldAstarteVersion)
+		fmt.Fprintf(os.Stderr, "I found no matching '%s' profile for Astarte %s. Maybe you spelled the profile wrong, or you should upgrade astartectl first?\n", newProfile, oldAstarteVersion)
 		os.Exit(1)
 	}
 
@@ -149,7 +149,7 @@ func instanceChangeProfileF(command *cobra.Command, args []string) error {
 	_, err = kubernetesDynamicClient.Resource(astarteV1Alpha1).Namespace(resourceNamespace).Patch(
 		context.TODO(), resourceName, types.MergePatchType, patch, v1.PatchOptions{})
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/cluster/instance_destroy.go
+++ b/cmd/cluster/instance_destroy.go
@@ -46,7 +46,7 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -54,12 +54,12 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 	}
 	deleteVolumes, err := command.Flags().GetBool("delete-volumes")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	if _, err := getAstarteInstance(resourceName, resourceNamespace); err != nil {
-		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
+		fmt.Fprintf(os.Stderr, "Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
 		os.Exit(1)
 	}
 
@@ -67,7 +67,7 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 	fmt.Println("WARNING: This operation is NOT REVERSIBLE and ALL DATA WILL BE LOST!!!")
 	confirmation, err := utils.PromptChoice("To continue, please enter the exact name of the Astarte instance you are deleting:", "", true)
 	if confirmation != resourceName {
-		fmt.Println("Aborting.")
+		fmt.Fprintln(os.Stderr, "Aborting.")
 		os.Exit(1)
 	}
 
@@ -75,8 +75,8 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 	// Kill it.
 	err = kubernetesDynamicClient.Resource(astarteV1Alpha1).Namespace(resourceNamespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("Error while destroying Astarte Resource.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Error while destroying Astarte Resource.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -86,7 +86,7 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 		fmt.Println("Deleting all Volumes...")
 		pvcList, err := kubernetesClient.CoreV1().PersistentVolumeClaims(resourceNamespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			fmt.Println("Could not list PVCs. You might need to delete Volumes manually.")
+			fmt.Fprintln(os.Stderr, "Could not list PVCs. You might need to delete Volumes manually.")
 			os.Exit(1)
 		}
 

--- a/cmd/cluster/instance_fetch_housekeeping_key.go
+++ b/cmd/cluster/instance_fetch_housekeeping_key.go
@@ -40,7 +40,7 @@ func fetchHKPrivateKeyF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -49,13 +49,13 @@ func fetchHKPrivateKeyF(command *cobra.Command, args []string) error {
 
 	keyData, err := getHousekeepingKey(resourceName, resourceNamespace, true)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	outputFile, err := command.Flags().GetString("output")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if outputFile == "" {
@@ -63,13 +63,13 @@ func fetchHKPrivateKeyF(command *cobra.Command, args []string) error {
 	} else {
 		outFile, err := os.Create(outputFile)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		defer outFile.Close()
 
 		if _, err := outFile.Write(keyData); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/cluster/instance_get_cluster_config.go
+++ b/cmd/cluster/instance_get_cluster_config.go
@@ -43,7 +43,7 @@ func instancesGetClusterConfigF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -56,7 +56,7 @@ func instancesGetClusterConfigF(command *cobra.Command, args []string) error {
 func doGetClusterConfig(resourceName, resourceNamespace string) error {
 	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
 	if err != nil {
-		fmt.Printf("Error while looking for instance %s: %s.\n", resourceName, err.Error())
+		fmt.Fprintf(os.Stderr, "Error while looking for instance %s: %s.\n", resourceName, err.Error())
 		os.Exit(1)
 	}
 	astarteSpec := astarteObject.Object["spec"].(map[string]interface{})
@@ -72,7 +72,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 	// Fetch key
 	keyData, err := getHousekeepingKey(resourceName, resourceNamespace, false)
 	if err != nil {
-		fmt.Printf("Error while fetching Housekeeping Key for instance %s: %s.\n", resourceName, err.Error())
+		fmt.Fprintf(os.Stderr, "Error while fetching Housekeeping Key for instance %s: %s.\n", resourceName, err.Error())
 		os.Exit(1)
 	}
 
@@ -86,7 +86,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 	configDir := config.GetConfigDir()
 
 	if err := config.SaveClusterConfiguration(configDir, clusterName, clusterConfig, true); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	fmt.Printf("Created new Cluster configuration %s\n", clusterName)
@@ -97,7 +97,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 		Cluster: clusterName,
 	}
 	if err := config.SaveContextConfiguration(configDir, contextName, contextConfig, true); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	fmt.Printf("Created new Context %s\n", contextName)
@@ -112,7 +112,7 @@ func doGetClusterConfig(resourceName, resourceNamespace string) error {
 
 	baseConfig.CurrentContext = contextName
 	if err := config.SaveBaseConfiguration(configDir, baseConfig); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	fmt.Printf("Context switched to %s\n", contextName)

--- a/cmd/cluster/instance_show.go
+++ b/cmd/cluster/instance_show.go
@@ -39,7 +39,7 @@ func instanceShowF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -48,7 +48,7 @@ func instanceShowF(command *cobra.Command, args []string) error {
 
 	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
 	if err != nil {
-		fmt.Printf("Error while looking for instance %s: %s.\n", resourceName, err.Error())
+		fmt.Fprintf(os.Stderr, "Error while looking for instance %s: %s.\n", resourceName, err.Error())
 		os.Exit(1)
 	}
 

--- a/cmd/cluster/instance_upgrade.go
+++ b/cmd/cluster/instance_upgrade.go
@@ -50,7 +50,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 	resourceName := args[0]
 	resourceNamespace, err := command.Flags().GetString("namespace")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	if resourceNamespace == "" {
@@ -59,7 +59,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 
 	astarteObject, err := getAstarteInstance(resourceName, resourceNamespace)
 	if err != nil {
-		fmt.Printf("Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
+		fmt.Fprintf(os.Stderr, "Could not find resource %s in namespace %s.\n", resourceName, resourceNamespace)
 		os.Exit(1)
 	}
 
@@ -67,12 +67,12 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 	_, deploymentManager, deploymentProfile := getManagedAstarteResourceStatus(*astarteObject)
 	oldAstarteVersion, err := semver.NewVersion(astarteSpec["version"].(string))
 	if err != nil {
-		fmt.Printf("Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
+		fmt.Fprintf(os.Stderr, "Installed version %s is not a valid Astarte version. Please ensure your Astarte installation is manageable by astartectl.", astarteSpec["version"].(string))
 		os.Exit(1)
 	}
 
 	if deploymentManager != "astartectl" {
-		fmt.Println("WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
+		fmt.Fprintln(os.Stderr, "WARNING: It looks like this Astarte deployment isn't managed by astartectl. On paper, everything should still work, but have extra care in reviewing changes once done.")
 	}
 
 	// Good. Let's check the version now.
@@ -89,13 +89,13 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 		}
 		version, err = utils.PromptChoice("What Astarte version would you like to upgrade to?", latestAstarteVersion, false)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
 	astarteVersion, err := semver.NewVersion(version)
 	if err != nil {
-		fmt.Printf("%s is not a valid Astarte version", version)
+		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte version", version)
 		os.Exit(1)
 	}
 
@@ -110,7 +110,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 		fmt.Println("It looks like this deployment has no profile associated. To move forward, you should probably associate a profile. You may choose not to, but in that case, I won't be able to help you if anything changed in the Operator.")
 		associateProfile, err := utils.AskForConfirmation("Would you like to associate a profile?")
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		if associateProfile {
@@ -120,7 +120,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 			// Get the profile
 			deploymentProfile, astarteDeployment, err = promptForProfile(command, astarteVersion)
 			if err != nil {
-				fmt.Println(err)
+				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
 		} else {
@@ -132,7 +132,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 		// and call it a day.
 		astarteDeployment = deployment.GetMatchingProfile(deploymentProfile, astarteVersion)
 		if !astarteDeployment.IsValid() {
-			fmt.Printf("I found no matching '%s' profile for Astarte %s. Maybe upgrade astartectl?\n", deploymentProfile, version)
+			fmt.Fprintf(os.Stderr, "I found no matching '%s' profile for Astarte %s. Maybe upgrade astartectl?\n", deploymentProfile, version)
 			os.Exit(1)
 		}
 		fmt.Println("Found a matching profile. Let me handle the hard stuff for you then, you're in good hands!")
@@ -183,7 +183,7 @@ func instanceUpgradeF(command *cobra.Command, args []string) error {
 	_, err = kubernetesDynamicClient.Resource(astarteV1Alpha1).Namespace(resourceNamespace).Patch(
 		context.TODO(), resourceName, types.MergePatchType, patch, v1.PatchOptions{})
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/cluster/profile_helpers.go
+++ b/cmd/cluster/profile_helpers.go
@@ -77,14 +77,14 @@ func createAstarteResourceFromExistingSpecOrDie(command *cobra.Command, resource
 		case types.Int:
 			i, err := strconv.Atoi(stringValue)
 			if err != nil {
-				fmt.Printf("%v is not a valid value for %v.\n", stringValue, customizableField.Field)
+				fmt.Fprintf(os.Stderr, "%v is not a valid value for %v.\n", stringValue, customizableField.Field)
 				os.Exit(1)
 			}
 			customFields[customizableField.Field] = i
 		case types.Bool:
 			b, err := strconv.ParseBool(stringValue)
 			if err != nil {
-				fmt.Printf("%v is not a valid value for %v.\n", stringValue, customizableField.Field)
+				fmt.Fprintf(os.Stderr, "%v is not a valid value for %v.\n", stringValue, customizableField.Field)
 				os.Exit(1)
 			}
 			customFields[customizableField.Field] = b
@@ -106,12 +106,12 @@ func createAstarteResourceFromExistingSpecOrDie(command *cobra.Command, resource
 
 	astarteDeploymentYaml, err := yaml.Marshal(astarteK8sDeployment)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	astarteDeploymentResource, err := utils.UnmarshalYAMLToJSON(astarteDeploymentYaml)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	// Go with the custom fields

--- a/cmd/cluster/uninstall_operator.go
+++ b/cmd/cluster/uninstall_operator.go
@@ -61,7 +61,7 @@ func clusterUninstallF(command *cobra.Command, args []string) error {
 	if !nonInteractive {
 		confirmation, err := utils.AskForConfirmation("Do you want to continue?")
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		if !confirmation {
@@ -73,48 +73,48 @@ func clusterUninstallF(command *cobra.Command, args []string) error {
 	err = kubernetesClient.AppsV1().Deployments("kube-system").Delete(
 		context.TODO(), "astarte-operator", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Astarte Operator Deployment.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Astarte Operator Deployment.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	// Delete Cluster Role Binding
 	err = kubernetesClient.RbacV1().ClusterRoleBindings().Delete(
 		context.TODO(), "astarte-operator", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Cluster Role Binding.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Cluster Role Binding.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	// Delete Cluster Role
 	err = kubernetesClient.RbacV1().ClusterRoles().Delete(
 		context.TODO(), "astarte-operator", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Cluster Role.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Cluster Role.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	// Delete Service Account
 	err = kubernetesClient.CoreV1().ServiceAccounts("kube-system").Delete(
 		context.TODO(), "astarte-operator", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Service Account.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Service Account.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	// Delete Astarte CRD
 	err = kubernetesAPIExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(
 		context.TODO(), "astartes.api.astarte-platform.org", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Astarte CRD.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Astarte CRD.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	// Delete AstarteVoyagerIngress CRD
 	err = kubernetesAPIExtensionsClient.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(
 		context.TODO(), "astartevoyageringresses.api.astarte-platform.org", metav1.DeleteOptions{})
 	if err != nil {
-		fmt.Println("WARNING: Could not delete Astarte CRD.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "WARNING: Could not delete Astarte CRD.")
+		fmt.Fprintln(os.Stderr, err)
 	}
 
 	fmt.Println("Astarte Operator has been successfully uninstalled from your cluster.")

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -48,16 +48,16 @@ func init() {
 func unmarshalYAML(res string, version string) runtime.Object {
 	content, err := getOperatorContent(res, version)
 	if err != nil {
-		fmt.Println("Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(content), nil, nil)
 	if err != nil {
-		fmt.Println("Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -75,8 +75,8 @@ func unmarshalOperatorContentYAMLToJSON(res string, version string) map[string]i
 	content, err := getOperatorContent(res, version)
 	jsonStruct, err := utils.UnmarshalYAMLToJSON([]byte(content))
 	if err != nil {
-		fmt.Println("Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	return jsonStruct
@@ -327,7 +327,7 @@ func promptForProfileExcluding(command *cobra.Command, astarteVersion *semver.Ve
 	profile := getStringFlagFromPromptOrDie(command, "profile", "Which profile would you like to deploy?", "", false)
 
 	if _, ok := unexcludedAvailableProfiles[profile]; !ok {
-		fmt.Printf("Profile %s does not exist! Aborting.\n", profile)
+		fmt.Fprintf(os.Stderr, "Profile %s does not exist! Aborting.\n", profile)
 		os.Exit(1)
 	}
 
@@ -372,7 +372,7 @@ func getStringFromSpecOrFlag(spec map[string]interface{}, field string, command 
 
 	fl, err := command.Flags().GetString(flagName)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -404,7 +404,7 @@ func getStringFlagFromPromptOrDie(command *cobra.Command, flagName string, quest
 		var err error
 		ret, err = command.Flags().GetString(flagName)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -417,7 +417,7 @@ func getStringFlagFromPromptOrDie(command *cobra.Command, flagName string, quest
 func getFromPromptOrDie(command *cobra.Command, question string, defaultValue string, allowEmpty bool) string {
 	ret, err := utils.PromptChoice(question, defaultValue, allowEmpty)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	return ret

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -102,7 +102,7 @@ You can also specify the flag multiple times instead of separating it with a com
 func realmsListF(command *cobra.Command, args []string) error {
 	realms, err := astarteAPIClient.Housekeeping.ListRealms()
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -115,7 +115,7 @@ func realmsShowF(command *cobra.Command, args []string) error {
 
 	realmDetails, err := astarteAPIClient.Housekeeping.GetRealm(realm)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -184,7 +184,7 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	}
 	astarteURL, err := url.Parse(urlString)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	contextName := ""
@@ -235,23 +235,23 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	case publicKey != "":
 		publicKeyContent, err = ioutil.ReadFile(publicKey)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	case privateKey != "":
 		privateKeyContent, err = ioutil.ReadFile(privateKey)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyContent)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
 		if publicKeyContent, err = getPublicKeyPEMBytes(&key.PublicKey); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	default:
@@ -263,12 +263,12 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 		}
 
 		if privateKeyContent, err = getPrivateKeyPEMBytes(key); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
 		if publicKeyContent, err = getPublicKeyPEMBytes(&key.PublicKey); err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	}
@@ -283,7 +283,7 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	}
 
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -309,10 +309,10 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 
 	configDir := config.GetConfigDir()
 	if err := config.SaveContextConfiguration(configDir, contextName, configContext, true); err != nil {
-		fmt.Printf("Could not save cluster configuration: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Could not save cluster configuration: %s\n", err)
 		if privateKey == "" {
 			// Dump the private key
-			fmt.Println("Dumping private key for reference")
+			fmt.Fprintln(os.Stderr, "Dumping private key for reference")
 			fmt.Println(string(privateKeyContent))
 		}
 	} else {

--- a/cmd/pairing/agent.go
+++ b/cmd/pairing/agent.go
@@ -72,7 +72,7 @@ func agentRegisterF(command *cobra.Command, args []string) error {
 
 	credentialsSecret, err := astarteAPIClient.Pairing.RegisterDevice(realm, deviceID)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -101,7 +101,7 @@ func agentUnregisterF(command *cobra.Command, args []string) error {
 	if !nonInteractive {
 		confirmation, err := utils.AskForConfirmation("Do you want to continue?")
 		if err != nil {
-			fmt.Println(err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 		if !confirmation {
@@ -111,7 +111,7 @@ func agentUnregisterF(command *cobra.Command, args []string) error {
 
 	err = astarteAPIClient.Pairing.UnregisterDevice(realm, deviceID)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -124,7 +124,7 @@ func init() {
 func interfacesListF(command *cobra.Command, args []string) error {
 	realmInterfaces, err := astarteAPIClient.RealmManagement.ListInterfaces(realm)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -136,7 +136,7 @@ func interfacesVersionsF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
 	interfaceVersions, err := astarteAPIClient.RealmManagement.ListInterfaceMajorVersions(realm, interfaceName)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -154,13 +154,13 @@ func interfacesShowF(command *cobra.Command, args []string) error {
 
 	interfaceDefinition, err := astarteAPIClient.RealmManagement.GetInterface(realm, interfaceName, interfaceMajor)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
 	respJSON, err := json.MarshalIndent(interfaceDefinition, "", "  ")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	fmt.Println(string(respJSON))
@@ -179,7 +179,7 @@ func interfacesInstallF(command *cobra.Command, args []string) error {
 	}
 
 	if err = astarteAPIClient.RealmManagement.InstallInterface(realm, interfaceBody); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -192,7 +192,7 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 	interfaceMajor := 0
 
 	if err := astarteAPIClient.RealmManagement.DeleteInterface(realm, interfaceName, interfaceMajor); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -213,7 +213,7 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 
 	if err = astarteAPIClient.RealmManagement.UpdateInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion,
 		astarteInterface); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/realm/triggers.go
+++ b/cmd/realm/triggers.go
@@ -83,7 +83,7 @@ func init() {
 func triggersListF(command *cobra.Command, args []string) error {
 	realmTriggers, err := astarteAPIClient.RealmManagement.ListTriggers(realm)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -96,7 +96,7 @@ func triggersShowF(command *cobra.Command, args []string) error {
 
 	triggerDefinition, err := astarteAPIClient.RealmManagement.GetTrigger(realm, triggerName)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -119,7 +119,7 @@ func triggersInstallF(command *cobra.Command, args []string) error {
 
 	err = astarteAPIClient.RealmManagement.InstallTrigger(realm, triggerBody)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
@@ -131,7 +131,7 @@ func triggersDeleteF(command *cobra.Command, args []string) error {
 	triggerName := args[0]
 	err := astarteAPIClient.RealmManagement.DeleteTrigger(realm, triggerName)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ See below for usage details`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/utils/device_id.go
+++ b/cmd/utils/device_id.go
@@ -119,7 +119,7 @@ func validateDeviceIDF(command *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
+	fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 	os.Exit(1)
 	return nil
 }
@@ -166,7 +166,7 @@ func computeDeviceIDFromBytesF(command *cobra.Command, args []string) error {
 func toUUIDDeviceIDF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	if !misc.IsValidAstarteDeviceID(deviceID) {
-		fmt.Printf("%s is not a valid Astarte Device ID\n", deviceID)
+		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 
@@ -183,7 +183,7 @@ func fromUUIDDeviceIDF(command *cobra.Command, args []string) error {
 	deviceUUID := args[0]
 	_, err := uuid.Parse(deviceUUID)
 	if err != nil {
-		fmt.Printf("%s is not a valid UUID\n", deviceUUID)
+		fmt.Fprintf(os.Stderr, "%s is not a valid UUID\n", deviceUUID)
 		os.Exit(1)
 	}
 

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -253,7 +253,7 @@ func savePublicPEMKey(fileName string, pubkey rsa.PublicKey) {
 
 func checkError(err error) {
 	if err != nil {
-		fmt.Println("Fatal error ", err.Error())
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Up to know, astartectl has been printing to stdout without caring much. This patch ensures that all errors or warnings or anything which is not meant to be shown to the user in a standard workflow is printed to stderr instead.