### PR TITLE
Switch releases to goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,25 @@
+name: Release
+# Run only on tag push
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v1
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: astartectl CI
+name: Build and Test
 on:
   # Run on mainline branches
   push:
@@ -20,26 +20,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go }}
       id: go
-    
-    - name: Install gox
-      run: go get github.com/mitchellh/gox && go install github.com/mitchellh/gox
-      # Releases are always on Go 1.14 and cross-compiled on Ubuntu (this is the tested configuration)
-      if: matrix.os == 'ubuntu-18.04' && matrix.go == '1.14.x'
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-
-    - name: Get dependencies
-      run: go get -v
+    - uses: actions/checkout@v2
 
     - name: Check gofmt
       run: diff -u <(echo -n) <(gofmt -d .)
       if: matrix.os != 'windows-latest'
-    
+
     - name: Run go vet
       run: go vet $(go list ./... | grep -v /vendor/)
 
@@ -48,98 +39,3 @@ jobs:
 
     - name: Test
       run: go test -v -race ./...
-    
-    - name: Run gox
-      run: mkdir bin && $HOME/go/bin/gox -os="darwin linux windows" -arch="amd64 386" -output="bin/astartectl_$TRAVIS_BRANCH_{{.OS}}_{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...
-      # Releases are always on Go 1.14 and cross-compiled on Ubuntu (this is the tested configuration)
-      if: matrix.os == 'ubuntu-18.04' && matrix.go == '1.14.x'
-    
-    - name: Upload Binaries
-      if: matrix.os == 'ubuntu-18.04' && matrix.go == '1.14.x'
-      uses: actions/upload-artifact@v1
-      with:
-        name: binaries
-        path: bin/
-
-  release:
-    name: Release
-    # Ensure we do this only for tags matching a version number
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'create'
-    needs: build
-    runs-on: ubuntu-18.04
-    steps:
-    - name: Craft release name
-      id: release_name_replace
-      uses: frabert/replace-string-action@v1.1
-      with:
-        pattern: 'refs/tags/v(\w+)'
-        string: ${{ github.ref }}
-        replace-with: '$1'
-    - name: Download built binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: binaries
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: "astartectl ${{ steps.release_name_replace.outputs.replaced }}"
-        # When the new action version is released, use this to plug in the changelog.
-        #body: |
-    - name: Upload Windows32 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_windows_386.exe
-        asset_name: astartectl_windows_386.exe
-        asset_content_type: application/vnd.microsoft.portable-executable
-    - name: Upload Windows64 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_windows_amd64.exe
-        asset_name: astartectl_windows_amd64.exe
-        asset_content_type: application/vnd.microsoft.portable-executable
-    - name: Upload Linux32 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_linux_386
-        asset_name: astartectl_linux_386
-        asset_content_type: application/octet-stream
-    - name: Upload Linux64 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_linux_amd64
-        asset_name: astartectl_linux_amd64
-        asset_content_type: application/octet-stream
-    - name: Upload Darwin32 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_darwin_386
-        asset_name: astartectl_darwin_386
-        asset_content_type: application/octet-stream
-    - name: Upload Darwin64 Release
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./binaries/astartectl_darwin_amd64
-        asset_name: astartectl_darwin_amd64
-        asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ main
 astartectl
 astartectl_*
 .gobuild
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,86 @@
+project_name: astartectl
+
+before:
+  hooks:
+    - go mod download
+builds:
+- id: astartectl
+  binary: astartectl
+  goos:
+    - linux
+    - darwin
+    - windows
+  env:
+  - CGO_ENABLED=0
+
+archives:
+  - id: astartectl
+
+    # Package binaries only
+    files:
+    - none*
+
+    replacements:
+      amd64: x86_64
+      386: i386
+      darwin: macOS
+
+    # Deliver as a zip file on Windows
+    format_overrides:
+      - goos: windows
+        format: zip
+
+nfpms:
+  # note that this is an array of nfpm configs
+  - id: astartectl
+    package_name: astartectl
+
+    # Replacements for GOOS and GOARCH in the package name.
+    # Keys should be valid GOOSs or GOARCHs.
+    # Values are the respective replacements.
+    # Default is empty.
+    replacements:
+      amd64: x86_64
+      386: i386
+
+    vendor: Ispirata
+    # Your app's homepage.
+    # Default is empty.
+    homepage: https://github.com/astarte-platform/astartectl
+
+    # Your app's maintainer (probably you).
+    # Default is empty.
+    maintainer: Astarte Developers <info@astarte-platform.org>
+
+    # Your app's description.
+    # Default is empty.
+    description: Command-line tool to manage Astarte Clusters.
+
+    # Your app's license.
+    # Default is empty.
+    license: Apache 2.0
+
+    # Formats to be generated.
+    formats:
+      - deb
+      - rpm
+
+    # Override default /usr/local/bin destination for binaries
+    bindir: /usr/bin
+
+    scripts:
+      postinstall: "scripts/postinstall.sh"
+      preremove: "scripts/preremove.sh"
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+release:
+  prerelease: auto
+  name_template: "astartectl {{.Version}}"
+  # Release as a draft, after review and changelog we'll release manually
+  draft: true
+changelog:
+  # We have our own way to track changes
+  skip: true

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Bash completion
+mkdir -p /etc/bash_completion.d
+astartectl completion bash > /etc/bash_completion.d/astartectl
+
+# ZSH completion
+mkdir -p /usr/share/zsh/vendor-completions
+astartectl completion zsh > /usr/share/zsh/vendor-completions/_astartectl

--- a/scripts/preremove.sh
+++ b/scripts/preremove.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Bash completion
+rm /etc/bash_completion.d/astartectl || true
+
+# ZSH completion
+rm /usr/share/zsh/vendor-completions/_astartectl || true


### PR DESCRIPTION
This drops manual release support with `gox` and uses goreleaser to build artifacts and packages.