### PR TITLE
Enhance appengine devices list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for printing device details in `appengine devices list`
 - Add support for filtering recently active devices in `appengine devices list`
+- Add support for filtering connected/disconnected devices in `appengine devices list`
 
 ## [0.11.2] - 2020-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.3] - Unreleased
+### Added
+- Add support for printing device details in `appengine devices list`
 
 ## [0.11.2] - 2020-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - Unreleased
+
 ## [0.11.2] - 2020-10-22
 ### Added
 - Add support for EC keys for JWT generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.3] - Unreleased
 ### Added
 - Add support for printing device details in `appengine devices list`
+- Add support for filtering recently active devices in `appengine devices list`
 
 ## [0.11.2] - 2020-10-22
 ### Added

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -17,6 +17,7 @@ package appengine
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -118,6 +119,24 @@ this is automatically determined - however, you can tweak this behavior by using
 
 var supportedOutputTypes = []string{"default", "csv", "json"}
 
+// DeviceFilterType represents the possible filter types for the device list
+type DeviceFilterType string
+
+const (
+	// ActiveSince allows to filter devices that connected at least once since a
+	// timestamp. Its filter value must be a timestamp in ISO8601 format.
+	ActiveSinceFilter DeviceFilterType = "active-since"
+)
+
+// IsValid returns an error if DeviceFilterType does not represent a valid Astarte Mapping Type
+func (f DeviceFilterType) IsValid() error {
+	switch f {
+	case ActiveSinceFilter:
+		return nil
+	}
+	return errors.New("invalid filter type")
+}
+
 func isASupportedOutputType(outputType string) bool {
 	for _, s := range supportedOutputTypes {
 		if s == outputType {
@@ -131,6 +150,12 @@ func init() {
 	AppEngineCmd.AddCommand(devicesCmd)
 
 	devicesListCmd.Flags().BoolP("details", "d", false, "When set, return the device list with all the DeviceDetails. Otherwise, just return the Device ID")
+
+	filtersDoc := `Filter to restrict the device list. Filters must be expressed in the form <filter-type>=<filter-value>. If more than one filter is passed, they will be combined with an AND operation.
+These are the currently supported filter-types:
+active-since: allows to filter devices that connected at least once since a specific timestamp. Its filter value must be a timestamp in ISO8601 format. Usage example: -f active-since=2020-11-12T00:00:00Z`
+
+	devicesListCmd.Flags().StringSliceP("filter", "f", []string{}, filtersDoc)
 
 	devicesGetSamplesCmd.Flags().IntP("count", "c", 10000, "Number of samples to be retrieved. Defaults to 10000. Setting this to 0 retrieves all samples.")
 	devicesGetSamplesCmd.Flags().Bool("ascending", false, "When set, returns samples in ascending order rather than descending.")
@@ -168,37 +193,141 @@ func devicesListF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	if details {
-		paginator, err := astarteAPIClient.AppEngine.GetDeviceListPaginator(realm, 50)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+	rawDeviceFilters, err := command.Flags().GetStringSlice("filter")
+	if err != nil {
+		return err
+	}
 
-		for hasNext := paginator.HasNextPage(); hasNext; hasNext = paginator.HasNextPage() {
-			page, err := paginator.GetNextDeviceDetailsPage()
-			if err != nil {
-				fmt.Println(err)
-				os.Exit(1)
-			}
+	deviceFiltersMap, err := buildDeviceFilters(rawDeviceFilters)
+	if err != nil {
+		return err
+	}
 
-			for _, deviceDetails := range page {
-				prettyPrintDeviceDetails(deviceDetails)
-				fmt.Println()
-			}
-		}
-
+	if !details && len(deviceFiltersMap) == 0 {
+		printSimpleDevicesList(realm)
 	} else {
-		devices, err := astarteAPIClient.AppEngine.ListDevices(realm)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+		printDevicesList(realm, details, deviceFiltersMap)
 
-		fmt.Println(devices)
 	}
 
 	return nil
+}
+
+func printSimpleDevicesList(realm string) {
+	devices, err := astarteAPIClient.AppEngine.ListDevices(realm)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Println(devices)
+}
+
+func printDevicesList(realm string, details bool, deviceFilters map[DeviceFilterType]interface{}) {
+	paginator, err := astarteAPIClient.AppEngine.GetDeviceListPaginator(realm, 100, client.DeviceDetailsFormat)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// This will be used only if details is false
+	deviceIDList := []string{}
+
+	hasFilters := len(deviceFilters) > 0
+
+	for hasNext := paginator.HasNextPage(); hasNext; hasNext = paginator.HasNextPage() {
+		page := []client.DeviceDetails{}
+		err := paginator.GetNextPage(&page)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		for _, deviceDetails := range page {
+			if hasFilters && !deviceShouldBeIncluded(deviceDetails, deviceFilters) {
+				continue
+			}
+
+			if details {
+				// If we want details, we print the list as we go
+				prettyPrintDeviceDetails(deviceDetails)
+				fmt.Println()
+			} else {
+				// Otherwise, we populate the deviceIDList
+				deviceIDList = append(deviceIDList, deviceDetails.DeviceID)
+			}
+		}
+	}
+
+	if !details {
+		fmt.Println(deviceIDList)
+	}
+}
+
+func deviceShouldBeIncluded(device client.DeviceDetails, deviceFilters map[DeviceFilterType]interface{}) bool {
+	for filterType, filterValue := range deviceFilters {
+		if !acceptedByFilter(device, filterType, filterValue) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func acceptedByFilter(device client.DeviceDetails, filterType DeviceFilterType, filterValue interface{}) bool {
+	switch filterType {
+	case ActiveSinceFilter:
+		// If it's currently connected, then it surely was active
+		if device.Connected {
+			return true
+		}
+
+		ts := filterValue.(time.Time)
+
+		// Otherwise, we check if the device disconnected after the beginning of the range.
+		// If so, the device was active during the time frame
+		return device.LastDisconnection.After(ts)
+	}
+
+	// Should never end up here, if we do we accept everything
+	return true
+}
+
+func buildDeviceFilters(rawDeviceFilters []string) (map[DeviceFilterType]interface{}, error) {
+	emptyMap := map[DeviceFilterType]interface{}{}
+	ret := emptyMap
+
+	for _, filter := range rawDeviceFilters {
+		s := strings.Split(filter, "=")
+		if len(s) != 2 {
+			return emptyMap, errors.New("Invalid filter format")
+		}
+
+		filterType := DeviceFilterType(s[0])
+		rawFilterValue := s[1]
+
+		err := filterType.IsValid()
+		if err != nil {
+			return emptyMap, errors.New("Invalid filter type: " + s[0])
+		}
+
+		switch filterType {
+		case ActiveSinceFilter:
+			t, err := time.Parse(time.RFC3339, rawFilterValue)
+			if err != nil {
+				return emptyMap, errors.New("Invalid filter value for active-since filter: " + rawFilterValue)
+			}
+
+			if t.After(time.Now()) {
+				return emptyMap, errors.New("Timestamp for active-since must be in the past")
+			}
+
+			ret[filterType] = t
+
+		}
+	}
+
+	return ret, nil
 }
 
 func prettyPrintDeviceDetails(deviceDetails client.DeviceDetails) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.11.2"
+var version = "0.11.3"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
-	github.com/astarte-platform/astarte-go v0.0.0-20201019144134-034b33222f08
+	github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52
 	github.com/go-openapi/strfmt v0.19.3 // indirect
 	github.com/google/go-github/v30 v30.1.0
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/astarte-platform/astarte-go v0.0.0-20201019144134-034b33222f08 h1:FQpW+asev0z9HNK5GnvLcrIpxlIorcxJNeHGSw4BBho=
 github.com/astarte-platform/astarte-go v0.0.0-20201019144134-034b33222f08/go.mod h1:z3qfyKDldol0qjw6ongq72DmMj2TbwNzxLYhcVm+tF4=
+github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52 h1:d+3fU/W7kih7CMaFTHefLWmQXSwrSRTe2fn5Noze8ws=
+github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52/go.mod h1:z3qfyKDldol0qjw6ongq72DmMj2TbwNzxLYhcVm+tF4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Allow printing a detailed list of devices and add the ability of filter devices using different predicates (`active-since` and `connected`, for now).

Fix #118 and #41 