### PR TITLE
Device: replace metadata with attributes

### DIFF
--- a/cmd/appengine/device_attributes.go
+++ b/cmd/appengine/device_attributes.go
@@ -22,70 +22,70 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// MetadataCmd represents the metadata command
-var metadataCmd = &cobra.Command{
-	Use:   "metadata",
-	Short: "Interact with Device Metadata",
-	Long:  `Perform actions on Astarte Device Metadata.`,
+// AttributesCmd represents the attributes command
+var attributesCmd = &cobra.Command{
+	Use:   "attributes",
+	Short: "Interact with Device Attributes",
+	Long:  `Perform actions on Astarte Device Attributes.`,
 }
 
-var metadataListCmd = &cobra.Command{
+var attributesListCmd = &cobra.Command{
 	Use:   "list <device_id_or_alias>",
-	Short: "List metadata",
-	Long: `List all metadata for a given Device.
+	Short: "List attributes",
+	Long: `List all attributes for a given Device.
 
 <device_id_or_alias> can be either a valid Astarte Device ID, or a Device Alias. In most cases,
 this is automatically determined - however, you can tweak this behavior by using --force-device-id or
 --force-id-type={device-id,alias}.`,
-	Example: `  astartectl appengine devices metadata list`,
+	Example: `  astartectl appengine devices attributes list`,
 	Args:    cobra.ExactArgs(1),
-	RunE:    metadataListF,
+	RunE:    attributesListF,
 	Aliases: []string{"ls"},
 }
 
-var metadataSetCmd = &cobra.Command{
+var attributeSetCmd = &cobra.Command{
 	Use:   "set <device_id_or_alias> <key>=<value>",
-	Short: "Set device metadata",
-	Long: `Set a value to a metadata key in the given Device, in the form <key>=<value>.
+	Short: "Set device attribute",
+	Long: `Set a value to an attribute key in the given Device, in the form <key>=<value>.
 This is effectively an upsert operation: if the key already exist, the new value overwrites the old one.
 
 <device_id_or_alias> can be either a valid Astarte Device ID, or a Device Alias. In most cases,
 this is automatically determined - however, you can tweak this behavior by using --force-device-id or
 --force-id-type={device-id,alias}.`,
-	Example: `  astartectl appengine devices metadata add 2TBn-jNESuuHamE2Zo1anA room=kitchen`,
+	Example: `  astartectl appengine devices attributes add 2TBn-jNESuuHamE2Zo1anA room=kitchen`,
 	Args:    cobra.ExactArgs(2),
-	RunE:    metadataSetF,
+	RunE:    attributeSetF,
 }
 
-var metadataRemoveCmd = &cobra.Command{
+var attributeRemoveCmd = &cobra.Command{
 	Use:   "remove <device_id_or_alias> <key>",
-	Short: "Remove metadata from a Device",
-	Long: `Remove metadata from the given Device, by specifying the key that has to be removed.
+	Short: "Remove attribute from a Device",
+	Long: `Remove attribute from the given Device, by specifying the key that has to be removed.
 
 <device_id_or_alias> can be either a valid Astarte Device ID, or a Device Alias. In most cases,
 this is automatically determined - however, you can tweak this behavior by using --force-device-id or
 --force-id-type={device-id,alias}.`,
-	Example: `  astartectl appengine devices metadata remove 2TBn-jNESuuHamE2Zo1anA room`,
+	Example: `  astartectl appengine devices attributes remove 2TBn-jNESuuHamE2Zo1anA room`,
 	Args:    cobra.ExactArgs(2),
-	RunE:    metadataRemoveF,
+	RunE:    attributeRemoveF,
 	Aliases: []string{"rm"},
 }
 
 func init() {
-	devicesCmd.AddCommand(metadataCmd)
+	devicesCmd.AddCommand(attributesCmd)
 
-	metadataListCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
-	metadataSetCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
-	metadataRemoveCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
+	attributesListCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
+	attributeSetCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
+	attributeRemoveCmd.Flags().String("force-id-type", "", "When set, rather than autodetecting, it forces the device ID to be evaluated as a (device-id,alias).")
 
-	metadataCmd.AddCommand(
-		metadataListCmd,
-		metadataSetCmd,
-		metadataRemoveCmd,
+	attributesCmd.AddCommand(
+		attributesListCmd,
+		attributeSetCmd,
+		attributeRemoveCmd,
 	)
 }
 
-func metadataListF(command *cobra.Command, args []string) error {
+func attributesListF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	forceIDType, err := command.Flags().GetString("force-id-type")
 	if err != nil {
@@ -96,17 +96,17 @@ func metadataListF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	metadata, err := astarteAPIClient.AppEngine.ListDeviceMetadata(realm, deviceID, deviceIdentifierType)
+	attributes, err := astarteAPIClient.AppEngine.ListDeviceAttributes(realm, deviceID, deviceIdentifierType)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("%v\n", metadata)
+	fmt.Printf("%v\n", attributes)
 	return nil
 }
 
-func metadataSetF(command *cobra.Command, args []string) error {
+func attributeSetF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	forceIDType, err := command.Flags().GetString("force-id-type")
 	if err != nil {
@@ -117,14 +117,14 @@ func metadataSetF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	metaKeyAndValue := args[1]
-	meta := strings.Split(metaKeyAndValue, "=")
-	if len(meta) != 2 {
-		fmt.Println("Metadata should be in the form <key>=<value>")
+	attributeKeyAndValue := args[1]
+	attr := strings.Split(attributeKeyAndValue, "=")
+	if len(attr) != 2 {
+		fmt.Println("Attributes should be in the form <key>=<value>")
 		os.Exit(1)
 	}
 
-	err = astarteAPIClient.AppEngine.SetDeviceMetadata(realm, deviceID, deviceIdentifierType, meta[0], meta[1])
+	err = astarteAPIClient.AppEngine.SetDeviceAttribute(realm, deviceID, deviceIdentifierType, attr[0], attr[1])
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -134,7 +134,7 @@ func metadataSetF(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func metadataRemoveF(command *cobra.Command, args []string) error {
+func attributeRemoveF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
 	forceIDType, err := command.Flags().GetString("force-id-type")
 	if err != nil {
@@ -147,7 +147,7 @@ func metadataRemoveF(command *cobra.Command, args []string) error {
 
 	key := args[1]
 
-	err = astarteAPIClient.AppEngine.DeleteDeviceMetadata(realm, deviceID, deviceIdentifierType, key)
+	err = astarteAPIClient.AppEngine.DeleteDeviceAttribute(realm, deviceID, deviceIdentifierType, key)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20200131002437-cf55d5288a48
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1
-	github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52
+	github.com/astarte-platform/astarte-go v0.90.2-0.20210324155635-ea3ab729656f
 	github.com/google/go-github/v30 v30.1.0
-	github.com/google/uuid v1.1.2
+	github.com/google/uuid v1.2.0
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/astarte-platform/astarte-go v0.0.0-20201019144134-034b33222f08 h1:FQpW+asev0z9HNK5GnvLcrIpxlIorcxJNeHGSw4BBho=
-github.com/astarte-platform/astarte-go v0.0.0-20201019144134-034b33222f08/go.mod h1:z3qfyKDldol0qjw6ongq72DmMj2TbwNzxLYhcVm+tF4=
-github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52 h1:d+3fU/W7kih7CMaFTHefLWmQXSwrSRTe2fn5Noze8ws=
-github.com/astarte-platform/astarte-go v0.0.0-20201118151044-4ba5fe0a4e52/go.mod h1:z3qfyKDldol0qjw6ongq72DmMj2TbwNzxLYhcVm+tF4=
+github.com/astarte-platform/astarte-go v0.90.2-0.20210324155635-ea3ab729656f h1:Zk5Kmuqg7vuyAoz1ocD+TF/c0W59Abb9Uo49Q8oNvU4=
+github.com/astarte-platform/astarte-go v0.90.2-0.20210324155635-ea3ab729656f/go.mod h1:mW8KuuYUMvO91z4HHYpa3e841jZPnp269fuXGl+c8WU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -87,8 +85,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/cristalhq/jwt/v3 v3.0.4 h1:1x04GZr04SJ3vd1Fsbl9eCPAuLwl753P7ywWgISrndo=
-github.com/cristalhq/jwt/v3 v3.0.4/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
+github.com/cristalhq/jwt/v3 v3.0.11 h1:oQAo2wlS8O/BUG03yIlDRzBrCwdAOiP52M1QRCk7MzI=
+github.com/cristalhq/jwt/v3 v3.0.11/go.mod h1:XOnIXst8ozq/esy5N1XOlSyQqBd+84fxJ99FK+1jgL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -200,8 +198,8 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -243,8 +241,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/orderedmap v0.1.0 h1:2orAxZBJsvimgEBmMWfXaFlzSG2fbQil5qzP3F6cCkg=
-github.com/iancoleman/orderedmap v0.1.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=


### PR DESCRIPTION
To keep coherency in terminology replace device metadata with device
attributes.