### PR TITLE
Fix `cluster show` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0] - Unreleased
+### Changed
+- `cluster show`: add operator-name and operator-namespace flags
 
 ## [1.0.0-beta.7] - 2022-02-09
 ### Added

--- a/cmd/cluster/show.go
+++ b/cmd/cluster/show.go
@@ -32,11 +32,24 @@ var showCmd = &cobra.Command{
 }
 
 func init() {
+	showCmd.PersistentFlags().String("operator-name", "astarte-operator-controller-manager", "The name of the Astarte Operator instance.")
+	showCmd.PersistentFlags().String("operator-namespace", "kube-system", "The namespace in which the Astarte Operator resides.")
+
 	ClusterCmd.AddCommand(showCmd)
 }
 
 func clusterShowF(command *cobra.Command, args []string) error {
-	operator, err := getAstarteOperator()
+	operatorName, err := command.Flags().GetString("operator-name")
+	if err != nil {
+		return err
+	}
+
+	operatorNamespace, err := command.Flags().GetString("operator-namespace")
+	if err != nil {
+		return err
+	}
+
+	operator, err := getAstarteOperator(operatorName, operatorNamespace)
 	if err != nil {
 		fmt.Println("Could not find an Astarte Operator Deployment on this Kubernetes Cluster.")
 		fmt.Println()

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -141,8 +141,8 @@ func getAstarte(astarteCRD dynamic.NamespaceableResourceInterface, name string, 
 	return astarteCRD.Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
-func getAstarteOperator() (*appsv1.Deployment, error) {
-	return kubernetesClient.AppsV1().Deployments("kube-system").Get(context.TODO(), "astarte-operator", metav1.GetOptions{})
+func getAstarteOperator(operatorName, operatorNamespace string) (*appsv1.Deployment, error) {
+	return kubernetesClient.AppsV1().Deployments(operatorNamespace).Get(context.TODO(), operatorName, metav1.GetOptions{})
 }
 
 func getLastOperatorRelease() (string, error) {


### PR DESCRIPTION
The `cluster show` command was not working properly because of the hardcoded operator's name and namespace.
Add `operator-name` and `operator-namespace` flags to handle non standard naming choices. Also, set reasonable defaults for covering standard scenarios.