### PR TITLE
Bump `astarte-go`

### DIFF
--- a/cmd/utils/device_id.go
+++ b/cmd/utils/device_id.go
@@ -137,7 +137,7 @@ func generateRandomDeviceIDF(command *cobra.Command, args []string) error {
 func computeDeviceIDFromStringF(command *cobra.Command, args []string) error {
 	namespaceUUID := args[0]
 	stringData := args[1]
-	deviceID, err := misc.GetNamespacedAstarteDeviceID(namespaceUUID, []byte(stringData))
+	deviceID, err := misc.GenerateAstarteDeviceID(namespaceUUID, []byte(stringData))
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func computeDeviceIDFromBytesF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	deviceID, err := misc.GetNamespacedAstarteDeviceID(namespaceUUID, actualBytes)
+	deviceID, err := misc.GenerateAstarteDeviceID(namespaceUUID, actualBytes)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.90.2
+	github.com/astarte-platform/astarte-go v0.90.4
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-github/v30 v30.1.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.90.2 h1:vLlkPbwGBtrfWZKrY72A4QBV2Y7GSSbog0I1/M7LIDU=
-github.com/astarte-platform/astarte-go v0.90.2/go.mod h1:UXoxDXd+4fYThjiUp3xulwzfg2m0StQbDyrUaKHXrio=
+github.com/astarte-platform/astarte-go v0.90.4 h1:yRXeYgTSfRbgwd6HrlaP9F2YLSROgWFyfmTm7qauGJ0=
+github.com/astarte-platform/astarte-go v0.90.4/go.mod h1:n2sFLJoQ7wyZXy3DgzgsubtBEffAkVoluEP9us2lXtY=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Bump the `astarte-go` dependency to v0.90.4 and remove a function which has been deprecated.