### PR TITLE
Context: Stop warning about missing configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Unreleased
+### Fixed
+- context: do not warn when config is missing. Users will have to provide parameters by hand.
+
 ## [1.0.0] - 2022-06-13
 ### Added
 - `cluster instances migrate replace-voyager` allows to migrate a deprecated AstarteVoyagerIngress

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/astarte-platform/astartectl/cmd/appengine"
@@ -84,7 +85,7 @@ func init() {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	// If the config does not exist, do not warn - it's simply not there.
-	if err := config.ConfigureViper(cfgContext); err != nil && !os.IsNotExist(err) {
+	if err := config.ConfigureViper(cfgContext); err != nil && reflect.TypeOf(viper.ConfigFileNotFoundError{}) != reflect.TypeOf(err) {
 		fmt.Fprintf(os.Stderr, "warn: Error while loading configuration: %s\n", err.Error())
 	}
 


### PR DESCRIPTION
If a config file is missing, the user will have to provide parameters by hand.
This was the expected interaction, but a change in the viper library APIs made
astartectl always show a noisy `error while loading configuration` warning.