### PR TITLE
`cluster instance deploy`: add burst deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.1] - Unreleased
+## Added
+- `cluster instance deploy`: add `--burst` flag to deploy a burst Astarte instance. It 
+  should be used only in resource-constrained environments, such as CI. Only Astarte
+  0.11.x and 1.0.x are supported.
+
 ### Fixed
 - context: do not warn when config is missing. Users will have to provide parameters by hand.
 

--- a/cmd/cluster/deployment/all_profiles.go
+++ b/cmd/cluster/deployment/all_profiles.go
@@ -21,7 +21,9 @@ func GetAllBuiltinAstarteClusterProfiles() []AstarteClusterProfile {
 		astarteBasicProfile010,
 		// 0.11 profiles
 		astarteBasicProfile011,
+		astarteBurstProfile011,
 		// 1.0 profiles (good for 1.0 for now)
 		astarteBasicProfile10,
+		astarteBurstProfile10,
 	}
 }

--- a/cmd/cluster/deployment/burst_0.11.go
+++ b/cmd/cluster/deployment/burst_0.11.go
@@ -1,0 +1,79 @@
+// Copyright © 2022 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+var astarteBurstProfile011 AstarteClusterProfile = AstarteClusterProfile{
+	Name:        "burst",
+	Description: "Burst profile for test Clusters. No deterministic allocations, all Astarte Pods work on bursts.",
+	Requirements: AstarteProfileRequirements{
+		CPUAllocation:    2 * 1000,
+		MemoryAllocation: 5 * 1024 * 1024 * 1024,
+	},
+	Compatibility:      AstarteProfileCompatibility{},
+	DefaultSpec:        Astartev1alpha1DeploymentSpec{},
+	CustomizableFields: []AstarteProfileCustomizableField{},
+}
+
+func init() {
+	astarteBurstProfile011.Compatibility.MaxAstarteVersion, _ = semver.NewVersion("0.11.99")
+	astarteBurstProfile011.Compatibility.MinAstarteVersion, _ = semver.NewVersion("0.11.0")
+
+	// Let components burst only
+	astarteBurstProfile011.DefaultSpec.Components.Resources.Requests.CPU = "0m"
+	astarteBurstProfile011.DefaultSpec.Components.Resources.Requests.Memory = "2048M"
+	astarteBurstProfile011.DefaultSpec.Components.Resources.Limits.CPU = "0m"
+	astarteBurstProfile011.DefaultSpec.Components.Resources.Limits.Memory = "3072M"
+
+	// Queue size to a minimum, decent amount
+	astarteBasicProfile011.DefaultSpec.Components.DataUpdaterPlant.DataQueueCount = 128
+
+	// Very tiny Cassandra installation
+	astarteBurstProfile011.DefaultSpec.Cassandra.Deploy = true
+	astarteBurstProfile011.DefaultSpec.Cassandra.MaxHeapSize = "512M"
+	astarteBurstProfile011.DefaultSpec.Cassandra.HeapNewSize = "256M"
+	astarteBurstProfile011.DefaultSpec.Cassandra.Resources.Requests.CPU = "500m"
+	astarteBurstProfile011.DefaultSpec.Cassandra.Resources.Requests.Memory = "1024M"
+	astarteBurstProfile011.DefaultSpec.Cassandra.Resources.Limits.CPU = "1000m"
+	astarteBurstProfile011.DefaultSpec.Cassandra.Resources.Limits.Memory = "2048M"
+	astarteBurstProfile011.DefaultSpec.Cassandra.Storage.Size = "10Gi"
+
+	// Minimal CFSSL installation
+	astarteBurstProfile011.DefaultSpec.Cfssl.Deploy = true
+	astarteBurstProfile011.DefaultSpec.Cfssl.Resources.Requests.CPU = "0m"
+	astarteBurstProfile011.DefaultSpec.Cfssl.Resources.Requests.Memory = "128M"
+	astarteBurstProfile011.DefaultSpec.Cfssl.Resources.Limits.CPU = "0m"
+	astarteBurstProfile011.DefaultSpec.Cfssl.Resources.Limits.Memory = "128M"
+	astarteBurstProfile011.DefaultSpec.Cfssl.Storage.Size = "2Gi"
+
+	// Minimal RabbitMQ installation
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Deploy = true
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Resources.Requests.CPU = "200m"
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Resources.Requests.Memory = "256M"
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Resources.Limits.CPU = "1000m"
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Resources.Limits.Memory = "256M"
+	astarteBurstProfile011.DefaultSpec.Rabbitmq.Storage.Size = "4Gi"
+
+	// Minimal VerneMQ installation
+	astarteBurstProfile011.DefaultSpec.Vernemq.Deploy = true
+	astarteBurstProfile011.DefaultSpec.Vernemq.Resources.Requests.CPU = "200m"
+	astarteBurstProfile011.DefaultSpec.Vernemq.Resources.Requests.Memory = "256M"
+	astarteBurstProfile011.DefaultSpec.Vernemq.Resources.Limits.CPU = "1000m"
+	astarteBurstProfile011.DefaultSpec.Vernemq.Resources.Limits.Memory = "256M"
+	astarteBurstProfile011.DefaultSpec.Vernemq.Storage.Size = "4Gi"
+}

--- a/cmd/cluster/deployment/burst_1.0.go
+++ b/cmd/cluster/deployment/burst_1.0.go
@@ -1,0 +1,79 @@
+// Copyright © 2022 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployment
+
+import (
+	"github.com/Masterminds/semver/v3"
+)
+
+var astarteBurstProfile10 AstarteClusterProfile = AstarteClusterProfile{
+	Name:        "burst",
+	Description: "Burst profile for CI Clusters. No deterministic allocations, all Astarte Pods work on bursts.",
+	Requirements: AstarteProfileRequirements{
+		CPUAllocation:    2 * 1000,
+		MemoryAllocation: 5 * 1024 * 1024 * 1024,
+	},
+	Compatibility:      AstarteProfileCompatibility{},
+	DefaultSpec:        Astartev1alpha1DeploymentSpec{},
+	CustomizableFields: []AstarteProfileCustomizableField{},
+}
+
+func init() {
+	astarteBurstProfile10.Compatibility.MaxAstarteVersion, _ = semver.NewVersion("1.0.99")
+	astarteBurstProfile10.Compatibility.MinAstarteVersion, _ = semver.NewVersion("1.0.0")
+
+	// Let components burst only
+	astarteBurstProfile10.DefaultSpec.Components.Resources.Requests.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Components.Resources.Requests.Memory = "2048M"
+	astarteBurstProfile10.DefaultSpec.Components.Resources.Limits.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Components.Resources.Limits.Memory = "3072M"
+
+	// Queue size to a minimum, decent amount
+	astarteBurstProfile10.DefaultSpec.Components.DataUpdaterPlant.DataQueueCount = 128
+
+	// Very tiny Cassandra installation
+	astarteBurstProfile10.DefaultSpec.Cassandra.Deploy = true
+	astarteBurstProfile10.DefaultSpec.Cassandra.MaxHeapSize = "512M"
+	astarteBurstProfile10.DefaultSpec.Cassandra.HeapNewSize = "256M"
+	astarteBurstProfile10.DefaultSpec.Cassandra.Resources.Requests.CPU = "500m"
+	astarteBurstProfile10.DefaultSpec.Cassandra.Resources.Requests.Memory = "1024M"
+	astarteBurstProfile10.DefaultSpec.Cassandra.Resources.Limits.CPU = "1000m"
+	astarteBurstProfile10.DefaultSpec.Cassandra.Resources.Limits.Memory = "2048M"
+	astarteBurstProfile10.DefaultSpec.Cassandra.Storage.Size = "10Gi"
+
+	// Minimal CFSSL installation
+	astarteBurstProfile10.DefaultSpec.Cfssl.Deploy = true
+	astarteBurstProfile10.DefaultSpec.Cfssl.Resources.Requests.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Cfssl.Resources.Requests.Memory = "128M"
+	astarteBurstProfile10.DefaultSpec.Cfssl.Resources.Limits.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Cfssl.Resources.Limits.Memory = "128M"
+	astarteBurstProfile10.DefaultSpec.Cfssl.Storage.Size = "2Gi"
+
+	// Minimal RabbitMQ installation
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Deploy = true
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Resources.Requests.CPU = "200m"
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Resources.Requests.Memory = "256M"
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Resources.Limits.CPU = "1000m"
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Resources.Limits.Memory = "256M"
+	astarteBurstProfile10.DefaultSpec.Rabbitmq.Storage.Size = "4Gi"
+
+	// Minimal VerneMQ installation
+	astarteBurstProfile10.DefaultSpec.Vernemq.Deploy = true
+	astarteBurstProfile10.DefaultSpec.Vernemq.Resources.Requests.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Vernemq.Resources.Requests.Memory = "256M"
+	astarteBurstProfile10.DefaultSpec.Vernemq.Resources.Limits.CPU = "0m"
+	astarteBurstProfile10.DefaultSpec.Vernemq.Resources.Limits.Memory = "256M"
+	astarteBurstProfile10.DefaultSpec.Vernemq.Storage.Size = "4Gi"
+}

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -341,7 +341,7 @@ func promptForProfile(command *cobra.Command, astarteVersion *semver.Version) (s
 	return promptForProfileExcluding(command, astarteVersion, []string{})
 }
 
-func getBasicProfile(command *cobra.Command, astarteVersion *semver.Version) (string, deployment.AstarteClusterProfile, error) {
+func getProfile(command *cobra.Command, astarteVersion *semver.Version, burst bool) (string, deployment.AstarteClusterProfile, error) {
 	nodes, allocatableCPU, allocatableMemory, err := getClusterAllocatableResources()
 	if err != nil {
 		return "", deployment.AstarteClusterProfile{}, err
@@ -364,7 +364,13 @@ func getBasicProfile(command *cobra.Command, astarteVersion *semver.Version) (st
 		return "", deployment.AstarteClusterProfile{}, fmt.Errorf("Unfortunately, your cluster allocatable resources do not allow for an Astarte instance to be deployed")
 	}
 
-	// only "basic" type profiles are available at the moment
+	// Invariant: since burst requirements are a strict subset of basic requirements,
+	// if a cluster allows for a basic profile, it also allows for a burst one.
+	if burst {
+		return "burst", availableProfiles["burst"], nil
+	}
+
+	// basic type profiles are the default
 	return "basic", availableProfiles["basic"], nil
 }
 


### PR DESCRIPTION
Add the `--burst` flag to allow a burst Astarte instance to be deployed.
This is useful in resource-constrained environments, such as CI runners, where the basic instance would require too many resources. Supported only for Astarte 0.11.x and 1.0.x.
Partially revert de2d61a0fc37e4e504f025f6e94d4d51e8fc10af.