### PR TITLE
Add command to update storage version of selected CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `cluster instances migrate storage-version` allows to migrate CRDs with `[v1alpha1, v1alpha2]`
+  stored versions to just `[v1alpha2]`.
 
 ## [1.0.0] - 2022-06-13
 ### Added

--- a/cmd/cluster/instance_migrate.go
+++ b/cmd/cluster/instance_migrate.go
@@ -54,12 +54,15 @@ Before the actual migration starts, the user is required to review the to-be-ins
 var updateStorageVersionCmd = &cobra.Command{
 	Use:   "storage-version",
 	Short: "Update Astarte, AVI and Flow CRDs to the v1alpha2 storage version",
-	Long: `Update the storage version of Astarte, AstarteVoyagerIngress and Flow CRDs from v1alpha1 to v1alpha2.
+	Long: `Update the storage version of Astarte, AstarteVoyagerIngress and Flow CRDs from [v1alpha1, v1alpha2] to v1alpha2.
 	
-This is NOT a standalone command, please refer to the Astarte documentation for the complete upgrade procedure.`,
+This is NOT a standalone command, please refer to the Astarte documentation on the upgrade to Astarte Operator 1.1 for the complete upgrade procedure.`,
 	Example: `  astartectl cluster instances migrate storage-version`,
 	RunE:    updateStorageVersionCmdF,
 }
+
+var crdsStoredVersionsBeforeUpgrade = []string{"v1alpha1", "v1alpha2"}
+var crdsStoredVersionsAfterUpgrade = []string{"v1alpha2"}
 
 func init() {
 	InstancesCmd.AddCommand(MigrateCmd)
@@ -75,11 +78,33 @@ func init() {
 
 func updateStorageVersionCmdF(command *cobra.Command, args []string) error {
 	crds := []string{"astartes.api.astarte-platform.org", "astartevoyageringresses.api.astarte-platform.org", "flows.api.astarte-platform.org"}
+
+	crdsWithStoredVersions := map[string][]string{}
+	//check that required CRDs exist and save their current storedVersions, in case you need to restore them.
 	for _, v := range crds {
-		if err := updateStorageVersion(v); err != nil {
+		if crd, err := kubernetesAPIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(),
+			v, metav1.GetOptions{}); err != nil {
 			return err
+		} else {
+			crdsWithStoredVersions[v] = crd.Status.StoredVersions
 		}
 	}
+
+	// check that all 3 CRDs have the right storedVersions
+	for k, v := range crdsWithStoredVersions {
+		if !checkStoredVersionsMatch(v, crdsStoredVersionsBeforeUpgrade) {
+			return fmt.Errorf("CRD %s status not consistent with API migration. Refer to the Astarte documentation on the upgrade to Astarte Operator 1.1", k)
+		}
+	}
+
+	// if all preconditions are met, we can start upgrading the CRDs
+	if err := updateAllStoredVersions(crdsWithStoredVersions); err != nil {
+		// something went wrong, revert revert revert
+		return restoreAllStoredVersions(crdsWithStoredVersions)
+	}
+
+	fmt.Println("All CRDs were upgraded successfully!")
+
 	return nil
 }
 
@@ -606,48 +631,51 @@ func maybeNotifyForUnmanagedAnnotations(aviObj *unstructured.Unstructured) {
 	}
 }
 
-func updateStorageVersion(crdName string) error {
-	// First of all, some sanity checks
-	fmt.Printf("Checking migration preconditions for %s\n", crdName)
-	// get the CRD
-	crd, err := kubernetesAPIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(),
-		crdName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-
-	// ensure that we are performing the migration on a correctly configured CRD:
-	// at this point, the CRD should have both v1alpha1 and v1alpha2 as storedVersions
-	err = checkUpdateStorageVersionPreconditions(crd.Status.StoredVersions, []string{"v1alpha1", "v1alpha2"})
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Migrating %s\n", crdName)
-	// update the stored versions...
-	crd.Status.StoredVersions = []string{"v1alpha2"}
-
-	// ... and perform the CRD update
-	if err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := kubernetesAPIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(context.Background(), crd, metav1.UpdateOptions{})
-		if err != nil {
+func updateAllStoredVersions(crds map[string][]string) error {
+	for crd := range crds {
+		if err := updateStoredVersionsTo(crd, crdsStoredVersionsAfterUpgrade); err != nil {
+			fmt.Printf("Error updating %s: %s. Will restore CRDs.", crd, err.Error())
 			return err
 		}
-		return nil
-	}); err != nil {
-		return err
 	}
-
-	fmt.Printf("%s correctly migrated\n", crdName)
 	return nil
 }
 
-func checkUpdateStorageVersionPreconditions(currentStoredVersions []string, requiredStoredVersions []string) error {
-	if cmp.Equal(currentStoredVersions, requiredStoredVersions, cmpopts.SortSlices(func(a, b string) bool {
-		return a < b
-	})) {
-		return nil
-	} else {
-		return fmt.Errorf("CRD status not consistent with API migration. Refer to the Astarte documentation on how to perform migration")
+func restoreAllStoredVersions(crds map[string][]string) error {
+	fmt.Println("Restoring CRDs to the previous state...")
+	for crd, oldStoredVersions := range crds {
+		if err := updateStoredVersionsTo(crd, oldStoredVersions); err != nil {
+			return err
+		}
 	}
+	fmt.Println("Done. Please, check again the upgrade guide for Astarte Operator 1.1 before retrying.")
+	return nil
+}
+
+func updateStoredVersionsTo(crdName string, newStoredVersions []string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		crd, err := kubernetesAPIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(),
+			crdName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// if it has the desired storedVersions already, do nothing
+		if checkStoredVersionsMatch(crd.Status.StoredVersions, newStoredVersions) {
+			return nil
+		}
+
+		crd.Status.StoredVersions = newStoredVersions
+
+		if _, err = kubernetesAPIExtensionsClient.ApiextensionsV1().CustomResourceDefinitions().UpdateStatus(context.Background(), crd, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func checkStoredVersionsMatch(currentStoredVersions []string, requiredStoredVersions []string) bool {
+	return cmp.Equal(currentStoredVersions, requiredStoredVersions, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }

--- a/cmd/cluster/instance_migrate.go
+++ b/cmd/cluster/instance_migrate.go
@@ -56,7 +56,7 @@ var updateStorageVersionCmd = &cobra.Command{
 	Short: "Update Astarte, AVI and Flow CRDs to the v1alpha2 storage version",
 	Long: `Update the storage version of Astarte, AstarteVoyagerIngress and Flow CRDs from [v1alpha1, v1alpha2] to v1alpha2.
 	
-This is NOT a standalone command, please refer to the Astarte documentation on the upgrade to Astarte Operator 1.1 for the complete upgrade procedure.`,
+This is NOT a standalone command, please refer to the Astarte documentation on the upgrade to Astarte Operator v22.11 for the complete upgrade procedure.`,
 	Example: `  astartectl cluster instances migrate storage-version`,
 	RunE:    updateStorageVersionCmdF,
 }
@@ -93,7 +93,7 @@ func updateStorageVersionCmdF(command *cobra.Command, args []string) error {
 	// check that all 3 CRDs have the right storedVersions
 	for k, v := range crdsWithStoredVersions {
 		if !checkStoredVersionsMatch(v, crdsStoredVersionsBeforeUpgrade) {
-			return fmt.Errorf("CRD %s status not consistent with API migration. Refer to the Astarte documentation on the upgrade to Astarte Operator 1.1", k)
+			return fmt.Errorf("CRD %s status not consistent with API migration. Refer to the Astarte documentation on the upgrade to Astarte Operator 22.11", k)
 		}
 	}
 
@@ -648,7 +648,7 @@ func restoreAllStoredVersions(crds map[string][]string) error {
 			return err
 		}
 	}
-	fmt.Println("Done. Please, check again the upgrade guide for Astarte Operator 1.1 before retrying.")
+	fmt.Println("Done. Please, check again the upgrade guide for Astarte Operator v22.11 before retrying.")
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/astarte-platform/astarte-go v0.90.4
 	github.com/go-openapi/strfmt v0.21.1 // indirect
+	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0
 	github.com/google/uuid v1.3.0
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
@@ -34,7 +35,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/cristalhq/jwt/v3 v3.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/form3tech-oss/jwt-go v3.2.3+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
@@ -42,7 +42,6 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
@@ -58,7 +57,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,7 +164,6 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=
-github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -265,8 +264,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
 github.com/google/go-github/v30 v30.1.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -476,7 +476,6 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -927,7 +926,6 @@ golang.org/x/tools v0.1.6-0.20210820212750-d4cc65f0b2ff/go.mod h1:YD9qOF0M9xpSpd
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
Since the `v1alpha1` CRDs of Astarte, AVI and Flow will be deprecated (see the [related issue](https://github.com/astarte-platform/astarte-kubernetes-operator/issues/298)), add the `cluster instances migrate storage-version` command to update the CRDs' `status.storedVersions` field to include just `v1alpha2`.
The command checks that the CRDs are in the correct state before executing the upgrade, and reverts all changes if one CRD update fails.