### PR TITLE
Add support for ignoring SSL errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [22.11.01] - Unreleased
+### Added
+- Add support for ignoring SSL errors while interacting with the Astarte APIs.
+
 ## [22.11.00] - 2022-12-06
 ### Added
 - `cluster instances migrate storage-version` allows to migrate CRDs with `[v1alpha1, v1alpha2]`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,12 +66,24 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgContext, "context", "", "Configuration context to use. When not specified, defaults to current context.")
 	rootCmd.PersistentFlags().StringP("astarte-url", "u", "", "Base url for your Astarte deployment (e.g. https://api.astarte.example.com)")
 	rootCmd.PersistentFlags().StringP("token", "t", "", "Token for authenticating against Astarte APIs. When set, it takes precedence over any private key setting. Claims in the token have to match the permissions needed for the individual command.")
+	rootCmd.PersistentFlags().Bool("ignore-ssl-errors", false, "When set, ignore SSL errors towards the Astarte APIs.")
+
 	if err := viper.BindPFlag("config-dir", rootCmd.PersistentFlags().Lookup("config-dir")); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("astarte-url"))
-	viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token"))
+	if err := viper.BindPFlag("url", rootCmd.PersistentFlags().Lookup("astarte-url")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := viper.BindPFlag("ignore-ssl-errors", rootCmd.PersistentFlags().Lookup("ignore-ssl-errors")); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	rootCmd.AddCommand(housekeeping.HousekeepingCmd)
 	rootCmd.AddCommand(pairing.PairingCmd)


### PR DESCRIPTION
Ignoring SSL errors is beneficial when dealing with testing environments (or in all those cases in which self signed certificates are used). Thus, add support for bypassing SSL errors.
Contextually, add additional checks to prevent the linter from complaining that return values are not checked.

Fix #169 