### PR TITLE
Internals: move to the latest `astarte-go`

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -10,10 +10,10 @@ jobs:
     name: Release
     runs-on: ubuntu-20.04
     steps:
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.18.x
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        go: [1.17.x, 1.18.x]
+        go: [1.18.x, 1.19.x]
         os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.17.8
+golang 1.18.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `cluster instance deploy`: Astarte >= `v1.0.0` is deployed using the
   `api.astarte-platform.org/v1alpha2` API.
+- Require at least Go 1.18 (due to astarte-go dep).
+- Use Go 1.18 for releases.
 
 ### Fixed
 - `appengine devices send-data` correctly parses integers as int32 instead of in64.
   Fix [#176](https://github.com/astarte-platform/astartectl/issues/176).
-
-### Changed
-- Require at least Go 1.18 (due to astarte-go dep).
-- Use Go 1.18 for releases.
 
 ## [22.11.00] - 2022-12-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `appengine devices send-data` correctly parses integers as int32 instead of in64.
   Fix [#176](https://github.com/astarte-platform/astartectl/issues/176).
 
+### Changed
+- Require at least Go 1.18 (due to astarte-go dep).
+- Use Go 1.18 for releases.
+
 ## [22.11.00] - 2022-12-06
 ### Added
 - `cluster instances migrate storage-version` allows to migrate CRDs with `[v1alpha1, v1alpha2]`

--- a/cmd/appengine/appengine.go
+++ b/cmd/appengine/appengine.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/client"
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/deviceid"
 	"github.com/astarte-platform/astartectl/utils"
 
 	"github.com/spf13/cobra"
@@ -59,9 +60,9 @@ func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("Either astarte-url or appengine-url have to be specified")
 	}
 
-	individualURLVariables := map[misc.AstarteService]string{
-		misc.AppEngine:       "individual-urls.appengine",
-		misc.RealmManagement: "individual-urls.realm-management",
+	individualURLVariables := map[astarteservices.AstarteService]string{
+		astarteservices.AppEngine:       "individual-urls.appengine",
+		astarteservices.RealmManagement: "individual-urls.realm-management",
 	}
 
 	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
@@ -85,7 +86,7 @@ func deviceIdentifierTypeFromFlags(deviceIdentifier string, forceDeviceIdentifie
 	case "":
 		return client.AutodiscoverDeviceIdentifier, nil
 	case "device-id":
-		if !misc.IsValidAstarteDeviceID(deviceIdentifier) {
+		if !deviceid.IsValid(deviceIdentifier) {
 			return 0, fmt.Errorf("Required to evaluate the Device Identifier as an Astarte Device ID, but %v isn't a valid one", deviceIdentifier)
 		}
 		return client.AstarteDeviceID, nil

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -27,9 +27,10 @@ import (
 	"time"
 
 	"code.cloudfoundry.org/bytefmt"
+	"github.com/astarte-platform/astarte-go/astarteservices"
+	"github.com/astarte-platform/astarte-go/auth"
 	"github.com/astarte-platform/astarte-go/client"
 	"github.com/astarte-platform/astarte-go/interfaces"
-	"github.com/astarte-platform/astarte-go/misc"
 	"github.com/jedib0t/go-pretty/table"
 
 	"github.com/araddon/dateparse"
@@ -220,17 +221,39 @@ func devicesListF(command *cobra.Command, args []string) error {
 }
 
 func printSimpleDevicesList(realm string) {
-	devices, err := astarteAPIClient.AppEngine.ListDevices(realm)
+	paginator, err := astarteAPIClient.GetDeviceListPaginator(realm, 100, client.DeviceDetailsFormat)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	fmt.Println(devices)
+	deviceIDList := []string{}
+
+	for paginator.HasNextPage() {
+		nextPageCall, err := paginator.GetNextPage()
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		deviceListRes, err := nextPageCall.Run(astarteAPIClient)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		rawPage, _ := deviceListRes.Parse()
+		page, _ := rawPage.([]string)
+
+		for _, deviceID := range page {
+			deviceIDList = append(deviceIDList, deviceID)
+		}
+	}
+
+	fmt.Println(deviceIDList)
 }
 
 func printDevicesList(realm string, details bool, deviceFilters map[DeviceFilterType]interface{}) {
-	paginator, err := astarteAPIClient.AppEngine.GetDeviceListPaginator(realm, 100, client.DeviceDetailsFormat)
+	paginator, err := astarteAPIClient.GetDeviceListPaginator(realm, 100, client.DeviceDetailsFormat)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -241,13 +264,20 @@ func printDevicesList(realm string, details bool, deviceFilters map[DeviceFilter
 
 	hasFilters := len(deviceFilters) > 0
 
-	for hasNext := paginator.HasNextPage(); hasNext; hasNext = paginator.HasNextPage() {
-		page := []client.DeviceDetails{}
-		err := paginator.GetNextPage(&page)
+	for paginator.HasNextPage() {
+		nextPageCall, err := paginator.GetNextPage()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
+		deviceListRes, err := nextPageCall.Run(astarteAPIClient)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		rawPage, _ := deviceListRes.Parse()
+		page, _ := rawPage.([]client.DeviceDetails)
 
 		for _, deviceDetails := range page {
 			if hasFilters && !deviceShouldBeIncluded(deviceDetails, deviceFilters) {
@@ -411,7 +441,7 @@ func devicesShowF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
+	deviceDetails, err := deviceDetails(realm, deviceID, deviceIdentifierType)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -419,6 +449,22 @@ func devicesShowF(command *cobra.Command, args []string) error {
 
 	prettyPrintDeviceDetails(deviceDetails)
 	return nil
+}
+
+func deviceDetails(realm, deviceID string, deviceIdentifierType client.DeviceIdentifierType) (client.DeviceDetails, error) {
+	deviceDetailsCall, err := astarteAPIClient.GetDeviceDetails(realm, deviceID, deviceIdentifierType)
+	if err != nil {
+		return client.DeviceDetails{}, err
+	}
+
+	deviceDetailsRes, err := deviceDetailsCall.Run(astarteAPIClient)
+	if err != nil {
+		return client.DeviceDetails{}, err
+	}
+
+	rawDeviceDetails, _ := deviceDetailsRes.Parse()
+	deviceDetails, _ := rawDeviceDetails.(client.DeviceDetails)
+	return deviceDetails, nil
 }
 
 func tableWriterForOutputType(outputType string) table.Writer {
@@ -483,7 +529,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 	if snapshotInterface == "" {
 		t.AppendHeader(table.Row{"Interface", "Path", "Value", "Ownership", "Timestamp (Datastream only)"})
 
-		deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
+		deviceDetails, err := deviceDetails(realm, deviceID, deviceIdentifierType)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -491,8 +537,7 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 
 		for astarteInterface, interfaceIntrospection := range deviceDetails.Introspection {
 			// Query Realm Management to get details on the interface
-			interfaceDescription, err := astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface,
-				interfaceIntrospection.Major)
+			interfaceDescription, err := getInterfaceDefinition(realm, astarteInterface, interfaceIntrospection.Major)
 			if err != nil {
 				// If we're requesting a full snapshot, do not fail but just warn the user
 				fmt.Fprintf(os.Stderr, "warn: Could not fetch details for interface %s\n", astarteInterface)
@@ -522,55 +567,46 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 		switch i.Type {
 		case interfaces.DatastreamType:
 			if i.Aggregation == interfaces.ObjectAggregation {
-				if i.IsParametric() {
-					val, err := astarteAPIClient.AppEngine.GetAggregateParametricDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
-					if err != nil {
-						warnOrFail(snapshotInterface, i.Name, err)
-					}
-					for path, aggregate := range val {
-						if outputType == "json" {
-							jsonOutput[i.Name] = val
-						} else {
-							for _, k := range aggregate.Values.Keys() {
-								v, _ := aggregate.Values.Get(k)
-								if v == nil {
-									v = "(null)"
-								}
-								if snapshotInterface == "" {
-									t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v, i.Ownership,
-										timestampForOutput(aggregate.Timestamp, outputType)})
-								} else {
-									t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v,
-										timestampForOutput(aggregate.Timestamp, outputType)})
-								}
-							}
-						}
-					}
-				} else {
-					val, err := astarteAPIClient.AppEngine.GetAggregateDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
-					if err != nil {
-						warnOrFail(snapshotInterface, i.Name, err)
-					}
+				snapshotCall, err := astarteAPIClient.GetDatastreamObjectSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
+				if err != nil {
+					warnOrFail(snapshotInterface, i.Name, err)
+				}
+				snapshotRes, err := snapshotCall.Run(astarteAPIClient)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				rawVal, _ := snapshotRes.Parse()
+				val, _ := rawVal.(map[string]client.DatastreamObjectValue)
+				for path, aggregate := range val {
 					if outputType == "json" {
 						jsonOutput[i.Name] = val
 					} else {
-						for _, k := range val.Values.Keys() {
-							v, _ := val.Values.Get(k)
+						for _, k := range aggregate.Values.Keys() {
+							v, _ := aggregate.Values.Get(k)
 							if v == nil {
 								v = "(null)"
 							}
 							if snapshotInterface == "" {
-								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("/%s", k), v, i.Ownership,
-									timestampForOutput(val.Timestamp, outputType)})
+								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v, i.Ownership,
+									timestampForOutput(aggregate.Timestamp, outputType)})
 							} else {
-								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("/%s", k), v,
-									timestampForOutput(val.Timestamp, outputType)})
+								t.AppendRow([]interface{}{i.Name, fmt.Sprintf("%s/%s", path, k), v,
+									timestampForOutput(aggregate.Timestamp, outputType)})
 							}
 						}
 					}
 				}
+
 			} else {
-				val, err := astarteAPIClient.AppEngine.GetDatastreamSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
+				snapshotCall, err := astarteAPIClient.GetDatastreamIndividualSnapshot(realm, deviceID, deviceIdentifierType, i.Name)
+				snapshotRes, err := snapshotCall.Run(astarteAPIClient)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+				rawVal, _ := snapshotRes.Parse()
+				val, _ := rawVal.(map[string]client.DatastreamIndividualValue)
 				if err != nil {
 					warnOrFail(snapshotInterface, i.Name, err)
 				}
@@ -591,7 +627,14 @@ func devicesDataSnapshotF(command *cobra.Command, args []string) error {
 				jsonOutput[i.Name] = jsonRepresentation
 			}
 		case interfaces.PropertiesType:
-			val, err := astarteAPIClient.AppEngine.GetProperties(realm, deviceID, deviceIdentifierType, i.Name)
+			snapshotCall, err := astarteAPIClient.GetAllProperties(realm, deviceID, deviceIdentifierType, i.Name)
+			snapshotRes, err := snapshotCall.Run(astarteAPIClient)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			rawVal, _ := snapshotRes.Parse()
+			val, _ := rawVal.(map[string]client.PropertyValue)
 			if err != nil {
 				warnOrFail(snapshotInterface, i.Name, err)
 			}
@@ -698,7 +741,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 	if !skipRealmManagementChecks {
 		// Get the device introspection
 		interfaceFound := false
-		deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
+		deviceDetails, err := deviceDetails(realm, deviceID, deviceIdentifierType)
 		if err != nil {
 			return err
 		}
@@ -708,8 +751,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 			}
 
 			// Query Realm Management to get details on the interface
-			interfaceDescription, err := astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface,
-				interfaceIntrospection.Major)
+			interfaceDescription, err := getInterfaceDefinition(realm, astarteInterface, interfaceIntrospection.Major)
 			if err != nil {
 				return err
 			}
@@ -751,19 +793,30 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 		// Go with the table header
 		t.AppendHeader(table.Row{"Timestamp", "Value"})
 		printedValues := 0
-		jsonOutput := []client.DatastreamValue{}
-		datastreamPaginator, err := astarteAPIClient.AppEngine.GetDatastreamsTimeWindowPaginator(realm, deviceID,
-			deviceIdentifierType, interfaceName, interfacePath, sinceTime, toTime, resultSetOrder)
+		jsonOutput := []client.DatastreamIndividualValue{}
+		datastreamPaginator, err := astarteAPIClient.GetDatastreamIndividualTimeWindowPaginator(realm, deviceID,
+			deviceIdentifierType, interfaceName, interfacePath, sinceTime, toTime, resultSetOrder, 100)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		for ok := true; ok; ok = datastreamPaginator.HasNextPage() {
-			page, err := datastreamPaginator.GetNextPage()
+		for datastreamPaginator.HasNextPage() {
+			nextPageCall, err := datastreamPaginator.GetNextPage()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			nextPageRes, err := nextPageCall.Run(astarteAPIClient)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			rawPage, err := nextPageRes.Parse()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			page, _ := rawPage.([]client.DatastreamIndividualValue)
 
 			if outputType == "json" {
 				jsonOutput = append(jsonOutput, page...)
@@ -783,20 +836,31 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 		headerRow := table.Row{"Timestamp"}
 		headerPrinted := false
 
-		jsonOutput := []client.DatastreamAggregateValue{}
+		jsonOutput := []client.DatastreamObjectValue{}
 		printedValues := 0
-		datastreamPaginator, err := astarteAPIClient.AppEngine.GetDatastreamsTimeWindowPaginator(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath,
-			sinceTime, toTime, resultSetOrder)
+		datastreamPaginator, err := astarteAPIClient.GetDatastreamObjectTimeWindowPaginator(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath,
+			sinceTime, toTime, resultSetOrder, 100)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		for ok := true; ok; ok = datastreamPaginator.HasNextPage() {
-			page, err := datastreamPaginator.GetNextAggregatePage()
+		for datastreamPaginator.HasNextPage() {
+			nextPageCall, err := datastreamPaginator.GetNextPage()
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			nextPageRes, err := nextPageCall.Run(astarteAPIClient)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			rawPage, err := nextPageRes.Parse()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			page, _ := rawPage.([]client.DatastreamObjectValue)
 
 			if outputType == "json" {
 				jsonOutput = append(jsonOutput, page...)
@@ -933,18 +997,20 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 		parsedPayloadData = aggrPayload
 	}
 
+	var sendDataCall client.AstarteRequest
+
 	if !skipRealmManagementChecks {
 		// We can delegate the entirety of this to astarte-go
-		err = astarteAPIClient.AppEngine.SendData(realm, deviceID, deviceIdentifierType, iface, interfacePath, parsedPayloadData)
+		sendDataCall, err = astarteAPIClient.SendData(realm, deviceID, deviceIdentifierType, iface, interfacePath, parsedPayloadData)
 	} else {
 		// Don't risk it. Use raw functions and trust the server to fail, in case.
 		switch interfaceTypeString {
 		case "properties":
-			err = astarteAPIClient.AppEngine.SetProperty(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+			sendDataCall, err = astarteAPIClient.SetProperty(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
 		case "individual-datastream", "individual-parametric-datastream":
-			err = astarteAPIClient.AppEngine.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+			sendDataCall, err = astarteAPIClient.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
 		case "aggregate-datastream", "aggregate-parametric-datastream":
-			err = astarteAPIClient.AppEngine.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
+			sendDataCall, err = astarteAPIClient.SendDatastream(realm, deviceID, deviceIdentifierType, interfaceName, interfacePath, parsedPayloadData)
 		default:
 			err = fmt.Errorf("%s is not a valid Interface Type. Valid interface types are: properties, individual-datastream, aggregate-datastream, individual-parametric-datastream, aggregate-parametric-datastream", interfaceTypeString)
 		}
@@ -954,6 +1020,12 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	sendDataRes, err := sendDataCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_, _ = sendDataRes.Parse()
 
 	// Done
 	fmt.Println("ok")
@@ -967,7 +1039,7 @@ func shouldSkipRealmManagementChecks(cmd cobra.Command) (bool, error) {
 	}
 
 	// skip RM checks if explicitly requested, or if RM service is not set
-	if skipRealmManagementChecks || astarteAPIClient.RealmManagement == nil {
+	if skipRealmManagementChecks {
 		return true, nil
 	} else {
 		token, err := cmd.Flags().GetString("token")
@@ -975,7 +1047,7 @@ func shouldSkipRealmManagementChecks(cmd cobra.Command) (bool, error) {
 			return false, err
 		}
 
-		hasRealmManagementClaim, err := misc.IsJWTAstarteClaimValidForService(token, misc.RealmManagement)
+		hasRealmManagementClaim, err := auth.IsJWTAstarteClaimValidForService(token, astarteservices.RealmManagement)
 		// if the token is invalid, any Astarte API will return 403 forbidden
 		if err != nil {
 			return false, nil
@@ -1027,7 +1099,7 @@ func getProtoInterface(deviceID string, deviceIdentifierType client.DeviceIdenti
 		}
 	} else {
 		// Get the device introspection
-		deviceDetails, err := astarteAPIClient.AppEngine.GetDevice(realm, deviceID, deviceIdentifierType)
+		deviceDetails, err := deviceDetails(realm, deviceID, deviceIdentifierType)
 		if err != nil {
 			return iface, err
 		}
@@ -1038,7 +1110,7 @@ func getProtoInterface(deviceID string, deviceIdentifierType client.DeviceIdenti
 			}
 
 			// Query Realm Management to get details on the interface
-			iface, err = astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface,
+			iface, err = getInterfaceDefinition(realm, astarteInterface,
 				interfaceIntrospection.Major)
 			if err != nil {
 				// Die here, given we really can't recover further
@@ -1131,4 +1203,22 @@ func parseSendDataPayload(payload string, mappingType interfaces.AstarteMappingT
 	}
 
 	return ret, nil
+}
+
+func getInterfaceDefinition(realm, interfaceName string, interfaceMajor int) (interfaces.AstarteInterface, error) {
+	getInterfaceCall, err := astarteAPIClient.GetInterface(realm, interfaceName, interfaceMajor)
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+
+	getInterfaceRes, err := getInterfaceCall.Run(astarteAPIClient)
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+	rawInterface, err := getInterfaceRes.Parse()
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+	interfaceDefinition, _ := rawInterface.(interfaces.AstarteInterface)
+	return interfaceDefinition, nil
 }

--- a/cmd/appengine/device_aliases.go
+++ b/cmd/appengine/device_aliases.go
@@ -19,7 +19,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/client"
+	"github.com/astarte-platform/astarte-go/deviceid"
 	"github.com/spf13/cobra"
 )
 
@@ -72,15 +73,21 @@ func init() {
 
 func aliasesListF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
-	aliases, err := astarteAPIClient.AppEngine.ListDeviceAliases(realm, deviceID)
+	deviceAliasesCall, err := astarteAPIClient.ListDeviceAliases(realm, deviceID, client.AstarteDeviceID)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	deviceAliasesRes, err := deviceAliasesCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	aliases, _ := deviceAliasesRes.Parse()
 
 	fmt.Printf("%v\n", aliases)
 	return nil
@@ -88,7 +95,7 @@ func aliasesListF(command *cobra.Command, args []string) error {
 
 func aliasesAddF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
@@ -99,11 +106,19 @@ func aliasesAddF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	err := astarteAPIClient.AppEngine.AddDeviceAlias(realm, deviceID, s[0], s[1])
+	addDeviceCall, err := astarteAPIClient.AddDeviceAlias(realm, deviceID, s[0], s[1])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	addDeviceRes, err := addDeviceCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = addDeviceRes.Parse()
 
 	fmt.Println("ok")
 	return nil
@@ -111,17 +126,25 @@ func aliasesAddF(command *cobra.Command, args []string) error {
 
 func aliasesRemoveF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 	aliasTag := args[1]
 
-	err := astarteAPIClient.AppEngine.DeleteDeviceAlias(realm, deviceID, aliasTag)
+	deleteAliasCall, err := astarteAPIClient.DeleteDeviceAlias(realm, deviceID, aliasTag)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	deleteAliasRes, err := deleteAliasCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = deleteAliasRes.Parse()
 
 	fmt.Println("ok")
 	return nil

--- a/cmd/appengine/device_attributes.go
+++ b/cmd/appengine/device_attributes.go
@@ -96,11 +96,17 @@ func attributesListF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	attributes, err := astarteAPIClient.AppEngine.ListDeviceAttributes(realm, deviceID, deviceIdentifierType)
+	attributesCall, err := astarteAPIClient.ListDeviceAttributes(realm, deviceID, deviceIdentifierType)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+	attributesRes, err := attributesCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	attributes, _ := attributesRes.Parse()
 
 	fmt.Printf("%v\n", attributes)
 	return nil
@@ -124,11 +130,19 @@ func attributeSetF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	err = astarteAPIClient.AppEngine.SetDeviceAttribute(realm, deviceID, deviceIdentifierType, attr[0], attr[1])
+	setAttributeCall, err := astarteAPIClient.SetDeviceAttribute(realm, deviceID, deviceIdentifierType, attr[0], attr[1])
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	setAttributeRes, err := setAttributeCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = setAttributeRes.Parse()
 
 	fmt.Println("ok")
 	return nil
@@ -147,11 +161,19 @@ func attributeRemoveF(command *cobra.Command, args []string) error {
 
 	key := args[1]
 
-	err = astarteAPIClient.AppEngine.DeleteDeviceAttribute(realm, deviceID, deviceIdentifierType, key)
+	deleteAttributeCall, err := astarteAPIClient.DeleteDeviceAttribute(realm, deviceID, deviceIdentifierType, key)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	deleteAttributeRes, err := deleteAttributeCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = deleteAttributeRes.Parse()
 
 	fmt.Println("ok")
 	return nil

--- a/cmd/appengine/device_credentials.go
+++ b/cmd/appengine/device_credentials.go
@@ -17,7 +17,6 @@ package appengine
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -71,11 +70,15 @@ func devicesCredentialsInhibitF(command *cobra.Command, args []string) error {
 		return errors.New("The second argument should be one of: [true false]")
 	}
 
-	err = astarteAPIClient.AppEngine.InhibitDevice(realm, deviceID, deviceIdentifierType, inhibit)
+	inhibitDeviceReq, err := astarteAPIClient.SetDeviceInhibited(realm, deviceID, deviceIdentifierType, inhibit)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return err
 	}
+	inhibitDeviceRes, err := inhibitDeviceReq.Run(astarteAPIClient)
+	if err != nil {
+		return err
+	}
+	_, _ = inhibitDeviceRes.Parse()
 
 	fmt.Println("ok")
 	return nil

--- a/cmd/appengine/stats.go
+++ b/cmd/appengine/stats.go
@@ -45,10 +45,15 @@ func init() {
 }
 
 func statsDevicesF(command *cobra.Command, args []string) error {
-	devicesStats, err := astarteAPIClient.AppEngine.GetDevicesStats(realm)
+	devicesStatsReq, err := astarteAPIClient.GetDevicesStats(realm)
 	if err != nil {
 		return err
 	}
+	devicesStatsRes, err := devicesStatsReq.Run(astarteAPIClient)
+	if err != nil {
+		return err
+	}
+	devicesStats, _ := devicesStatsRes.Parse()
 
 	fmt.Printf("%+v\n", devicesStats)
 	return nil

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -15,8 +15,8 @@
 package housekeeping
 
 import (
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/client"
-	"github.com/astarte-platform/astarte-go/misc"
 	"github.com/astarte-platform/astartectl/utils"
 
 	"github.com/spf13/cobra"
@@ -45,7 +45,7 @@ func init() {
 
 func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	var err error
-	astarteAPIClient, err = utils.APICommandSetup(map[misc.AstarteService]string{misc.Housekeeping: "individual-urls.housekeeping"},
+	astarteAPIClient, err = utils.APICommandSetup(map[astarteservices.AstarteService]string{astarteservices.Housekeeping: "individual-urls.housekeeping"},
 		"housekeeping.key", "housekeeping.key-file")
 
 	return err

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -32,7 +32,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/auth"
+	"github.com/astarte-platform/astarte-go/client"
 	"github.com/astarte-platform/astartectl/config"
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
@@ -104,12 +105,18 @@ You can also specify the flag multiple times instead of separating it with a com
 }
 
 func realmsListF(command *cobra.Command, args []string) error {
-	realms, err := astarteAPIClient.Housekeeping.ListRealms()
+	realmsCall, err := astarteAPIClient.ListRealms()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-
+	realmsRes, err := realmsCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rawRealms, _ := realmsRes.Parse()
+	realms, _ := rawRealms.([]string)
 	fmt.Println(realms)
 	return nil
 }
@@ -117,11 +124,17 @@ func realmsListF(command *cobra.Command, args []string) error {
 func realmsShowF(command *cobra.Command, args []string) error {
 	realm := args[0]
 
-	realmDetails, err := astarteAPIClient.Housekeeping.GetRealm(realm)
+	getRealmDetailsCall, err := astarteAPIClient.GetRealm(realm)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	getRealmDetailsRes, err := getRealmDetailsCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	realmDetails, _ := getRealmDetailsRes.Parse()
 
 	fmt.Printf("%+v\n", realmDetails)
 	return nil
@@ -258,7 +271,7 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-		key, err := misc.ParsePrivateKeyFromPEM(privateKeyContent)
+		key, err := auth.ParsePrivateKeyFromPEM(privateKeyContent)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -286,19 +299,45 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 		}
 	}
 
-	if replicationFactor > 0 {
-		err = astarteAPIClient.Housekeeping.CreateRealmWithReplicationFactor(realm, string(publicKeyContent), replicationFactor)
-	} else if len(datacenterReplicationFactors) > 0 {
-		err = astarteAPIClient.Housekeeping.CreateRealmWithDatacenterReplication(realm, string(publicKeyContent),
-			datacenterReplicationFactors)
-	} else {
-		err = astarteAPIClient.Housekeeping.CreateRealm(realm, string(publicKeyContent))
-	}
+	var createRealmReq client.AstarteRequest
 
+	if replicationFactor > 0 {
+		createRealmReq, err = astarteAPIClient.CreateRealm(
+			client.WithRealmName(realm),
+			client.WithRealmPublicKey(string(publicKeyContent)),
+			client.WithReplicationFactor(replicationFactor),
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else if len(datacenterReplicationFactors) > 0 {
+		createRealmReq, err = astarteAPIClient.CreateRealm(
+			client.WithRealmName(realm),
+			client.WithRealmPublicKey(string(publicKeyContent)),
+			client.WithDatacenterReplicationFactors(datacenterReplicationFactors),
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	} else {
+		// TODO check if this is enough or we need to default the replication
+		createRealmReq, err = astarteAPIClient.CreateRealm(
+			client.WithRealmName(realm),
+			client.WithRealmPublicKey(string(publicKeyContent)),
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+	createRealmRes, err := createRealmReq.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	_, _ = createRealmRes.Parse()
 
 	fmt.Printf("Realm %s created successfully!\n", realm)
 

--- a/cmd/pairing/agent.go
+++ b/cmd/pairing/agent.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/deviceid"
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
@@ -68,11 +68,21 @@ func init() {
 func agentRegisterF(command *cobra.Command, args []string) error {
 	// TODO: add support for initial_introspection
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		return errors.New("Invalid device id")
 	}
 
-	credentialsSecret, err := astarteAPIClient.Pairing.RegisterDevice(realm, deviceID)
+	registerDeviceCall, err := astarteAPIClient.RegisterDevice(realm, deviceID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	registerDeviceRes, err := registerDeviceCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	credentialsSecret, err := registerDeviceRes.Parse()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -98,7 +108,7 @@ func agentRegisterF(command *cobra.Command, args []string) error {
 
 func agentUnregisterF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		return errors.New("Invalid device id")
 	}
 
@@ -119,11 +129,18 @@ func agentUnregisterF(command *cobra.Command, args []string) error {
 		}
 	}
 
-	err = astarteAPIClient.Pairing.UnregisterDevice(realm, deviceID)
+	unregisterDeviceCall, err := astarteAPIClient.UnregisterDevice(realm, deviceID)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	unregisterDeviceRes, err := unregisterDeviceCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	_, _ = unregisterDeviceRes.Parse()
 
 	fmt.Println("ok")
 	return nil

--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -17,8 +17,8 @@ package pairing
 import (
 	"errors"
 
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/client"
-	"github.com/astarte-platform/astarte-go/misc"
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -50,7 +50,7 @@ func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(
-		map[misc.AstarteService]string{misc.Pairing: "individual-urls.pairing"}, "realm.key", "realm.key-file")
+		map[astarteservices.AstarteService]string{astarteservices.Pairing: "individual-urls.pairing"}, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -124,11 +124,22 @@ func init() {
 }
 
 func interfacesListF(command *cobra.Command, args []string) error {
-	realmInterfaces, err := astarteAPIClient.RealmManagement.ListInterfaces(realm)
+	listInterfacesCall, err := astarteAPIClient.ListInterfaces(realm)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	listInterfacesRes, err := listInterfacesCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rawListInterfaces, err := listInterfacesRes.Parse()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	realmInterfaces, _ := rawListInterfaces.([]string)
 
 	fmt.Println(realmInterfaces)
 	return nil
@@ -136,11 +147,23 @@ func interfacesListF(command *cobra.Command, args []string) error {
 
 func interfacesVersionsF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
-	interfaceVersions, err := astarteAPIClient.RealmManagement.ListInterfaceMajorVersions(realm, interfaceName)
+	interfaceVersionsCall, err := astarteAPIClient.ListInterfaceMajorVersions(realm, interfaceName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	interfaceVersionsRes, err := interfaceVersionsCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rawInterfaceVersions, err := interfaceVersionsRes.Parse()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	interfaceVersions, _ := rawInterfaceVersions.([]int)
 
 	fmt.Println(interfaceVersions)
 	return nil
@@ -153,8 +176,7 @@ func interfacesShowF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	interfaceDefinition, err := astarteAPIClient.RealmManagement.GetInterface(realm, interfaceName, interfaceMajor)
+	interfaceDefinition, err := getInterfaceDefinition(realm, interfaceName, interfaceMajor)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -180,7 +202,7 @@ func interfacesInstallF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = astarteAPIClient.RealmManagement.InstallInterface(realm, interfaceBody); err != nil {
+	if err = installInterface(realm, interfaceBody); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -193,10 +215,18 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 	interfaceName := args[0]
 	interfaceMajor := 0
 
-	if err := astarteAPIClient.RealmManagement.DeleteInterface(realm, interfaceName, interfaceMajor); err != nil {
+	deleteInterfaceCall, err := astarteAPIClient.DeleteInterface(realm, interfaceName, interfaceMajor)
+	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	deleteInterfaceRes, err := deleteInterfaceCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = deleteInterfaceRes.Parse()
 
 	fmt.Println("ok")
 	return nil
@@ -213,8 +243,7 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = astarteAPIClient.RealmManagement.UpdateInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion,
-		astarteInterface); err != nil {
+	if err := updateInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion, astarteInterface); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
@@ -238,7 +267,7 @@ func interfacesSyncF(command *cobra.Command, args []string) error {
 			return err
 		}
 
-		if interfaceDefinition, err := astarteAPIClient.RealmManagement.GetInterface(realm, astarteInterface.Name, astarteInterface.MajorVersion); err != nil {
+		if interfaceDefinition, err := getInterfaceDefinition(realm, astarteInterface.Name, astarteInterface.MajorVersion); err != nil {
 			// The interface does not exist
 			interfacesToInstall = append(interfacesToInstall, astarteInterface)
 		} else {
@@ -281,19 +310,65 @@ func interfacesSyncF(command *cobra.Command, args []string) error {
 
 	// Start syncing.
 	for _, v := range interfacesToInstall {
-		if err := astarteAPIClient.RealmManagement.InstallInterface(realm, v); err != nil {
+		if err := installInterface(realm, v); err != nil {
 			fmt.Fprintf(os.Stderr, "Could not install interface %s: %s\n", v.Name, err)
 		} else {
 			fmt.Printf("Interface %s installed successfully\n", v.Name)
 		}
 	}
 	for _, v := range interfacesToUpdate {
-		if err := astarteAPIClient.RealmManagement.UpdateInterface(realm, v.Name, v.MajorVersion, v); err != nil {
+		if err := updateInterface(realm, v.Name, v.MajorVersion, v); err != nil {
 			fmt.Fprintf(os.Stderr, "Could not update interface %s: %s\n", v.Name, err)
 		} else {
 			fmt.Printf("Interface %s updated successfully to version %d.%d\n", v.Name, v.MajorVersion, v.MinorVersion)
 		}
 	}
 
+	return nil
+}
+
+func getInterfaceDefinition(realm, interfaceName string, interfaceMajor int) (interfaces.AstarteInterface, error) {
+	getInterfaceCall, err := astarteAPIClient.GetInterface(realm, interfaceName, interfaceMajor)
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+
+	getInterfaceRes, err := getInterfaceCall.Run(astarteAPIClient)
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+	rawInterface, err := getInterfaceRes.Parse()
+	if err != nil {
+		return interfaces.AstarteInterface{}, err
+	}
+	interfaceDefinition, _ := rawInterface.(interfaces.AstarteInterface)
+	return interfaceDefinition, nil
+}
+
+func installInterface(realm string, iface interfaces.AstarteInterface) error {
+	installInterfaceCall, err := astarteAPIClient.InstallInterface(realm, iface)
+	if err != nil {
+		return err
+	}
+	installInterfaceRes, err := installInterfaceCall.Run(astarteAPIClient)
+	if err != nil {
+		return err
+	}
+
+	_, _ = installInterfaceRes.Parse()
+	return nil
+}
+
+func updateInterface(realm string, interfaceName string, interfaceMajor int, newInterface interfaces.AstarteInterface) error {
+	updateInterfaceCall, err := astarteAPIClient.UpdateInterface(realm, interfaceName, interfaceMajor, newInterface)
+	if err != nil {
+		return err
+	}
+	updateInterfaceRes, err := updateInterfaceCall.Run(astarteAPIClient)
+	if err != nil {
+		return err
+	}
+
+	_, _ = updateInterfaceRes.Parse()
 	return nil
 }

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -17,8 +17,8 @@ package realm
 import (
 	"errors"
 
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/client"
-	"github.com/astarte-platform/astarte-go/misc"
 	"github.com/astarte-platform/astartectl/utils"
 
 	"github.com/spf13/cobra"
@@ -51,7 +51,7 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(
-		map[misc.AstarteService]string{misc.RealmManagement: "individual-urls.realm-management"}, "realm.key", "realm.key-file")
+		map[astarteservices.AstarteService]string{astarteservices.RealmManagement: "individual-urls.realm-management"}, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}

--- a/cmd/realm/triggers.go
+++ b/cmd/realm/triggers.go
@@ -81,12 +81,18 @@ func init() {
 }
 
 func triggersListF(command *cobra.Command, args []string) error {
-	realmTriggers, err := astarteAPIClient.RealmManagement.ListTriggers(realm)
+	realmTriggersCall, err := astarteAPIClient.ListTriggers(realm)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-
+	realmTriggersRes, err := realmTriggersCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	rawRealmTriggers, _ := realmTriggersRes.Parse()
+	realmTriggers, _ := rawRealmTriggers.([]string)
 	fmt.Println(realmTriggers)
 	return nil
 }
@@ -94,14 +100,21 @@ func triggersListF(command *cobra.Command, args []string) error {
 func triggersShowF(command *cobra.Command, args []string) error {
 	triggerName := args[0]
 
-	triggerDefinition, err := astarteAPIClient.RealmManagement.GetTrigger(realm, triggerName)
+	getTriggerCall, err := astarteAPIClient.GetTrigger(realm, triggerName)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	getTriggerRes, err := getTriggerCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
+	triggerDefinition, _ := getTriggerRes.Parse()
 	respJSON, _ := json.MarshalIndent(triggerDefinition, "", "  ")
 	fmt.Println(string(respJSON))
+
 	return nil
 }
 
@@ -117,11 +130,18 @@ func triggersInstallF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = astarteAPIClient.RealmManagement.InstallTrigger(realm, triggerBody)
+	installTriggerCall, err := astarteAPIClient.InstallTrigger(realm, triggerBody)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	installTriggerRes, err := installTriggerCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = installTriggerRes.Parse()
 
 	fmt.Println("ok")
 	return nil
@@ -129,11 +149,18 @@ func triggersInstallF(command *cobra.Command, args []string) error {
 
 func triggersDeleteF(command *cobra.Command, args []string) error {
 	triggerName := args[0]
-	err := astarteAPIClient.RealmManagement.DeleteTrigger(realm, triggerName)
+	deleteTriggerCall, err := astarteAPIClient.DeleteTrigger(realm, triggerName)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+	deleteTriggerRes, err := deleteTriggerCall.Run(astarteAPIClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	_, _ = deleteTriggerRes.Parse()
 
 	fmt.Println("ok")
 	return nil

--- a/cmd/utils/device_id.go
+++ b/cmd/utils/device_id.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/astarte-platform/astarte-go/misc"
+	"github.com/astarte-platform/astarte-go/deviceid"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
@@ -114,7 +114,7 @@ func init() {
 
 func validateDeviceIDF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if misc.IsValidAstarteDeviceID(deviceID) {
+	if deviceid.IsValid(deviceID) {
 		fmt.Println("Valid")
 		return nil
 	}
@@ -125,7 +125,7 @@ func validateDeviceIDF(command *cobra.Command, args []string) error {
 }
 
 func generateRandomDeviceIDF(command *cobra.Command, args []string) error {
-	deviceID, err := misc.GenerateRandomAstarteDeviceID()
+	deviceID, err := deviceid.GenerateRandom()
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func generateRandomDeviceIDF(command *cobra.Command, args []string) error {
 func computeDeviceIDFromStringF(command *cobra.Command, args []string) error {
 	namespaceUUID := args[0]
 	stringData := args[1]
-	deviceID, err := misc.GenerateAstarteDeviceID(namespaceUUID, []byte(stringData))
+	deviceID, err := deviceid.Generate(namespaceUUID, []byte(stringData))
 	if err != nil {
 		return err
 	}
@@ -154,7 +154,7 @@ func computeDeviceIDFromBytesF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	deviceID, err := misc.GenerateAstarteDeviceID(namespaceUUID, actualBytes)
+	deviceID, err := deviceid.Generate(namespaceUUID, actualBytes)
 	if err != nil {
 		return err
 	}
@@ -165,12 +165,12 @@ func computeDeviceIDFromBytesF(command *cobra.Command, args []string) error {
 
 func toUUIDDeviceIDF(command *cobra.Command, args []string) error {
 	deviceID := args[0]
-	if !misc.IsValidAstarteDeviceID(deviceID) {
+	if !deviceid.IsValid(deviceID) {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Device ID\n", deviceID)
 		os.Exit(1)
 	}
 
-	deviceUUID, err := misc.DeviceIDToUUID(deviceID)
+	deviceUUID, err := deviceid.ToUUID(deviceID)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func fromUUIDDeviceIDF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	deviceID, err := misc.UUIDToDeviceID(deviceUUID)
+	deviceID, err := deviceid.FromUUID(deviceUUID)
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/interfaces.go
+++ b/cmd/utils/interfaces.go
@@ -52,7 +52,7 @@ func init() {
 func validateInterfaceF(command *cobra.Command, args []string) error {
 	interfacePath := args[0]
 
-	if _, err := interfaces.ParseInterfaceFromFile(interfacePath); err != nil {
+	if _, err := interfaces.ParseInterfaceFrom(interfacePath); err != nil {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Interface: %s\n", interfacePath, err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.90.4
+	github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0
@@ -63,6 +63,9 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.7.5 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
@@ -79,6 +82,7 @@ require (
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
+	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/astarte-platform/astartectl
 
-go 1.17
+go 1.18
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.90.4 h1:yRXeYgTSfRbgwd6HrlaP9F2YLSROgWFyfmTm7qauGJ0=
-github.com/astarte-platform/astarte-go v0.90.4/go.mod h1:n2sFLJoQ7wyZXy3DgzgsubtBEffAkVoluEP9us2lXtY=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5 h1:b+Yux7iQsneSXP82cfF+p+4v8hAEhaKWKMI07olbypE=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -304,6 +304,7 @@ github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -315,7 +316,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
-github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -376,6 +376,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -516,7 +517,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
-github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0 h1:Xuk8ma/ibJ1fOy4Ee11vHhUFHQNpHhrBneOCNHVXS5w=
@@ -527,8 +527,10 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -568,8 +570,13 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
@@ -960,7 +967,6 @@ google.golang.org/api v0.57.0/go.mod h1:dVPlbZyBo2/OjBpmvNdpn2GRm6rPy75jyU7bmhdr
 google.golang.org/api v0.59.0/go.mod h1:sT2boj7M9YJxZzgeZqXogmhfmRWDtPzT31xkieUbuZU=
 google.golang.org/api v0.61.0/go.mod h1:xQRti5UdCmoCEqFxcz93fTl338AVqDgyaDRuOZ3hg9I=
 google.golang.org/api v0.62.0/go.mod h1:dKmwPCydfsad4qCH08MSdgWjfHOyfpd4VtDGgRFdavw=
-google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -1062,7 +1068,6 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1142,6 +1147,8 @@ k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lV
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+moul.io/http2curl v1.0.0 h1:6XwpyZOYsgZJrU8exnG87ncVkU1FVCcTRpwzOkTDUi8=
+moul.io/http2curl v1.0.0/go.mod h1:f6cULg+e4Md/oW1cYmwW4IWQOVl2lGbmCNGOHvzX2kE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/utils/client.go
+++ b/utils/client.go
@@ -23,17 +23,88 @@ import (
 	"strings"
 	"time"
 
+	"github.com/astarte-platform/astarte-go/astarteservices"
 	"github.com/astarte-platform/astarte-go/client"
-	"github.com/astarte-platform/astarte-go/misc"
 	"github.com/spf13/viper"
 )
 
 // APICommandSetup is a helper for setting up a generic command using Astarte API.
 // individualURLs must contain the service->variable association.
-func APICommandSetup(individualURLVariables map[misc.AstarteService]string, keyVariable, keyFileVariable string) (*client.Client, error) {
-	var astarteAPIClient *client.Client
+func APICommandSetup(individualURLVariables map[astarteservices.AstarteService]string, keyVariable, keyFileVariable string) (*client.Client, error) {
+	var clientConfig = []client.Option{}
+
+	httpConfig := setupHTTP()
+	clientConfig = append(clientConfig, httpConfig...)
+
+	authConfig, err := setupAuth(keyVariable, keyFileVariable)
+	if err != nil {
+		return nil, err
+	}
+	clientConfig = append(clientConfig, authConfig...)
+
+	URLConfig, err := setupURLs(individualURLVariables)
+	if err != nil {
+		return nil, err
+	}
+	clientConfig = append(clientConfig, URLConfig...)
+
+	astarteAPIClient, err := client.New(clientConfig...)
+	if err != nil {
+		return nil, err
+	}
+
+	return astarteAPIClient, nil
+}
+
+func setupHTTP() []client.Option {
+	var ret = []client.Option{}
+	ignoreSSLErrors := viper.GetBool("ignore-ssl-errors")
+	if ignoreSSLErrors {
+		httpClient := &http.Client{
+			Timeout: time.Second * 30,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: ignoreSSLErrors,
+				},
+			},
+		}
+		ret = append(ret, client.WithHTTPClient(httpClient))
+	}
+	return ret
+}
+
+func setupAuth(keyVariable, keyFileVariable string) ([]client.Option, error) {
+	var ret = []client.Option{}
+
+	// Setup auth
+	privateKeyFile := viper.GetString(keyFileVariable)
+	privateKey := viper.GetString(keyVariable)
+	explicitToken := viper.GetString("token")
+	if privateKey == "" && privateKeyFile == "" && explicitToken == "" {
+		return nil, fmt.Errorf("%s or token is required", strings.Replace(keyFileVariable, ".", "-", -1))
+	}
+	if explicitToken == "" {
+		// 1 minute TTL is more than enough for our purposes
+		if privateKeyFile != "" {
+			ret = append(ret, client.WithPrivateKey(privateKeyFile), client.WithExpiry(60))
+		} else {
+			decoded, err := base64.StdEncoding.DecodeString(privateKey)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, client.WithPrivateKey(decoded), client.WithExpiry(60))
+		}
+	} else {
+		ret = append(ret, client.WithJWT(explicitToken))
+	}
+	return ret, nil
+}
+
+func setupURLs(individualURLVariables map[astarteservices.AstarteService]string) ([]client.Option, error) {
+	var ret = []client.Option{}
+
 	astarteURL := viper.GetString("url")
-	individualURLs := map[misc.AstarteService]string{}
+	individualURLs := map[astarteservices.AstarteService]string{}
 	for k, v := range individualURLVariables {
 		urlOverride := viper.GetString(v)
 		if urlOverride != "" {
@@ -41,59 +112,30 @@ func APICommandSetup(individualURLVariables map[misc.AstarteService]string, keyV
 		}
 	}
 
-	ignoreSSLErrors := viper.GetBool("ignore-ssl-errors")
-	httpClient := &http.Client{
-		Timeout: time.Second * 30,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: ignoreSSLErrors,
-			},
-		},
-	}
-
-	var err error
 	if len(individualURLs) > 0 {
-		// Use explicit URLs for Service
-		astarteAPIClient, err = client.NewClientWithIndividualURLs(individualURLs, httpClient)
+		ret = append(ret, setupIndividualURLs(individualURLs)...)
 	} else if astarteURL != "" {
-		astarteAPIClient, err = client.NewClient(astarteURL, httpClient)
+		ret = append(ret, client.WithBaseURL(astarteURL))
 	} else {
-		err = errors.New("Either astarte-url or an individual API URL have to be specified")
+		return nil, errors.New("Either astarte-url or an individual API URL have to be specified")
 	}
+	return ret, nil
+}
 
-	if err != nil {
-		return nil, err
+func setupIndividualURLs(individualURLVariables map[astarteservices.AstarteService]string) []client.Option {
+	var ret = []client.Option{}
+	switch {
+	case individualURLVariables[astarteservices.Housekeeping] != "":
+		ret = append(ret, client.WithHousekeepingURL(individualURLVariables[astarteservices.Housekeeping]))
+		fallthrough
+	case individualURLVariables[astarteservices.AppEngine] != "":
+		ret = append(ret, client.WithAppEngineURL(individualURLVariables[astarteservices.AppEngine]))
+		fallthrough
+	case individualURLVariables[astarteservices.Pairing] != "":
+		ret = append(ret, client.WithPairingURL(individualURLVariables[astarteservices.Pairing]))
+		fallthrough
+	case individualURLVariables[astarteservices.RealmManagement] != "":
+		ret = append(ret, client.WithRealmManagementURL(individualURLVariables[astarteservices.RealmManagement]))
 	}
-
-	privateKeyFile := viper.GetString(keyFileVariable)
-	privateKey := viper.GetString(keyVariable)
-	explicitToken := viper.GetString("token")
-	if privateKey == "" && privateKeyFile == "" && explicitToken == "" {
-		return nil, fmt.Errorf("%s or token is required", strings.Replace(keyFileVariable, ".", "-", -1))
-	}
-
-	if explicitToken == "" {
-		servicesAndClaims := map[misc.AstarteService][]string{}
-		for k := range individualURLVariables {
-			servicesAndClaims[k] = []string{}
-		}
-		// 1 minute TTL is more than enough for our purposes
-		if privateKeyFile != "" {
-			if err := astarteAPIClient.SetTokenFromPrivateKeyFileWithClaims(privateKeyFile, servicesAndClaims, 60); err != nil {
-				return nil, err
-			}
-		} else {
-			decoded, err := base64.StdEncoding.DecodeString(privateKey)
-			if err != nil {
-				return nil, err
-			}
-			if err := astarteAPIClient.SetTokenFromPrivateKeyWithClaims(decoded, servicesAndClaims, 60); err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		astarteAPIClient.SetToken(explicitToken)
-	}
-
-	return astarteAPIClient, nil
+	return ret
 }


### PR DESCRIPTION
Astarte-go has introduced a [new API](https://github.com/astarte-platform/astarte-go/issues/30). Move to the new version, without breaking the current astartectl behaviour.
Contextually, bump Go to 1.18.