### PR TITLE
Allow printing a command-line equivalent of a command 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [22.11.01] - Unreleased
 ### Added
 - Add support for ignoring SSL errors while interacting with the Astarte APIs.
+- Add the `--to-curl` flag to print a command-line equivalent of a command instead
+  of running it.
 ### Changed
 - `cluster instance deploy`: Astarte >= `v1.0.0` is deployed using the
   `api.astarte-platform.org/v1alpha2` API.

--- a/cmd/appengine/appengine.go
+++ b/cmd/appengine/appengine.go
@@ -49,6 +49,9 @@ func init() {
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	AppEngineCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
+	AppEngineCmd.PersistentFlags().Bool("to-curl", false,
+		"When set, display a command-line equivalent instead of running the command.")
+	viper.BindPFlag("appengine-to-curl", AppEngineCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
@@ -77,6 +80,9 @@ func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 	if realm == "" {
 		return errors.New("realm is required")
 	}
+
+	// if just --to-curl is given, default to true
+	cmd.Flags().Lookup("to-curl").NoOptDefVal = "true"
 
 	return nil
 }

--- a/cmd/appengine/device_aliases.go
+++ b/cmd/appengine/device_aliases.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/astarte-platform/astarte-go/client"
 	"github.com/astarte-platform/astarte-go/deviceid"
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -82,6 +83,9 @@ func aliasesListF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(deviceAliasesCall, astarteAPIClient)
+
 	deviceAliasesRes, err := deviceAliasesCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -137,6 +141,8 @@ func aliasesRemoveF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(deleteAliasCall, astarteAPIClient)
 
 	deleteAliasRes, err := deleteAliasCall.Run(astarteAPIClient)
 	if err != nil {

--- a/cmd/appengine/device_attributes.go
+++ b/cmd/appengine/device_attributes.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -101,6 +102,9 @@ func attributesListF(command *cobra.Command, args []string) error {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(attributesCall, astarteAPIClient)
+
 	attributesRes, err := attributesCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -136,6 +140,8 @@ func attributeSetF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	utils.MaybeCurlAndExit(setAttributeCall, astarteAPIClient)
+
 	setAttributeRes, err := setAttributeCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -166,6 +172,8 @@ func attributeRemoveF(command *cobra.Command, args []string) error {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(deleteAttributeCall, astarteAPIClient)
 
 	deleteAttributeRes, err := deleteAttributeCall.Run(astarteAPIClient)
 	if err != nil {

--- a/cmd/appengine/device_credentials.go
+++ b/cmd/appengine/device_credentials.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -74,6 +75,9 @@ func devicesCredentialsInhibitF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	utils.MaybeCurlAndExit(inhibitDeviceReq, astarteAPIClient)
+
 	inhibitDeviceRes, err := inhibitDeviceReq.Run(astarteAPIClient)
 	if err != nil {
 		return err

--- a/cmd/appengine/groups.go
+++ b/cmd/appengine/groups.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/astarte-platform/astarte-go/client"
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -116,6 +117,8 @@ func groupsListF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	utils.MaybeCurlAndExit(groupsListCall, astarteAPIClient)
+
 	groupsListRes, err := groupsListCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -163,6 +166,8 @@ func groupsCreateF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
+	utils.MaybeCurlAndExit(createGroupCall, astarteAPIClient)
+
 	createGroupRes, err := createGroupCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -190,6 +195,9 @@ func groupsDevicesListF(command *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+
+		utils.MaybeCurlAndExit(deviceListCall, astarteAPIClient)
+
 		deviceListRes, err := deviceListCall.Run(astarteAPIClient)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -219,6 +227,9 @@ func groupsDevicesAddF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(addDeviceCall, astarteAPIClient)
+
 	addDeviceRes, err := addDeviceCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -243,6 +254,8 @@ func groupsDevicesRemoveF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(removeDeviceCall, astarteAPIClient)
 
 	removeDeviceRes, err := removeDeviceCall.Run(astarteAPIClient)
 	if err != nil {

--- a/cmd/appengine/stats.go
+++ b/cmd/appengine/stats.go
@@ -17,6 +17,7 @@ package appengine
 import (
 	"fmt"
 
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -49,6 +50,9 @@ func statsDevicesF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	utils.MaybeCurlAndExit(devicesStatsReq, astarteAPIClient)
+
 	devicesStatsRes, err := devicesStatsReq.Run(astarteAPIClient)
 	if err != nil {
 		return err

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -41,12 +41,18 @@ func init() {
 	HousekeepingCmd.PersistentFlags().String("housekeeping-url", "",
 		"Housekeeping API base URL. Defaults to <astarte-url>/housekeeping.")
 	viper.BindPFlag("individual-urls.housekeeping", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-url"))
+	HousekeepingCmd.PersistentFlags().Bool("to-curl", false,
+		"When set, display a command-line equivalent instead of running the command.")
+	viper.BindPFlag("housekeeping-to-curl", HousekeepingCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(map[astarteservices.AstarteService]string{astarteservices.Housekeeping: "individual-urls.housekeeping"},
 		"housekeeping.key", "housekeeping.key-file")
+
+	// if just --to-curl is given, default to true
+	cmd.Flags().Lookup("to-curl").NoOptDefVal = "true"
 
 	return err
 }

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -110,6 +110,9 @@ func realmsListF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(realmsCall, astarteAPIClient)
+
 	realmsRes, err := realmsCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -129,6 +132,9 @@ func realmsShowF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(getRealmDetailsCall, astarteAPIClient)
+
 	getRealmDetailsRes, err := getRealmDetailsCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -332,6 +338,9 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 			os.Exit(1)
 		}
 	}
+
+	utils.MaybeCurlAndExit(createRealmReq, astarteAPIClient)
+
 	createRealmRes, err := createRealmReq.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/pairing/agent.go
+++ b/cmd/pairing/agent.go
@@ -77,6 +77,9 @@ func agentRegisterF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(registerDeviceCall, astarteAPIClient)
+
 	registerDeviceRes, err := registerDeviceCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -134,6 +137,8 @@ func agentUnregisterF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(unregisterDeviceCall, astarteAPIClient)
 
 	unregisterDeviceRes, err := unregisterDeviceCall.Run(astarteAPIClient)
 	if err != nil {

--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -44,6 +44,9 @@ func init() {
 	viper.BindPFlag("individual-urls.pairing", PairingCmd.PersistentFlags().Lookup("pairing-url"))
 	PairingCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
+	PairingCmd.PersistentFlags().Bool("to-curl", false,
+		"When set, display a command-line equivalent instead of running the command.")
+	viper.BindPFlag("pairing-to-curl", PairingCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
@@ -60,6 +63,9 @@ func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	if realm == "" {
 		return errors.New("realm is required")
 	}
+
+	// if just --to-curl is given, default to true
+	cmd.Flags().Lookup("to-curl").NoOptDefVal = "true"
 
 	return nil
 }

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -24,6 +24,7 @@ import (
 	"github.com/astarte-platform/astarte-go/interfaces"
 	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // interfacesCmd represents the interfaces command
@@ -129,6 +130,9 @@ func interfacesListF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(listInterfacesCall, astarteAPIClient)
+
 	listInterfacesRes, err := listInterfacesCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -152,6 +156,8 @@ func interfacesVersionsF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(interfaceVersionsCall, astarteAPIClient)
 
 	interfaceVersionsRes, err := interfaceVersionsCall.Run(astarteAPIClient)
 	if err != nil {
@@ -220,6 +226,9 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(deleteInterfaceCall, astarteAPIClient)
+
 	deleteInterfaceRes, err := deleteInterfaceCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -253,6 +262,13 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 }
 
 func interfacesSyncF(command *cobra.Command, args []string) error {
+	// `interface sync` is unnatural btw
+	if viper.GetBool("to-curl") {
+		fmt.Println(`'interfaces sync' does not support the --to-curl option.
+Install or update your interfaces one by one with 'interfaces install' or 'interface update'.`)
+		os.Exit(1)
+	}
+
 	interfacesToInstall := []interfaces.AstarteInterface{}
 	interfacesToUpdate := []interfaces.AstarteInterface{}
 
@@ -333,6 +349,11 @@ func getInterfaceDefinition(realm, interfaceName string, interfaceMajor int) (in
 		return interfaces.AstarteInterface{}, err
 	}
 
+	// When we're here in the context of `interfaces sync`, the to-curl flag
+	// is always false (`interfaces sync` has no `--to-curl` flag)
+	// and thus the call will never exit unexpectedly
+	utils.MaybeCurlAndExit(getInterfaceCall, astarteAPIClient)
+
 	getInterfaceRes, err := getInterfaceCall.Run(astarteAPIClient)
 	if err != nil {
 		return interfaces.AstarteInterface{}, err
@@ -350,6 +371,12 @@ func installInterface(realm string, iface interfaces.AstarteInterface) error {
 	if err != nil {
 		return err
 	}
+
+	// When we're here in the context of `interfaces sync`, the to-curl flag
+	// is always false (`interfaces sync` has no `--to-curl` flag)
+	// and thus the call will never exit unexpectedly
+	utils.MaybeCurlAndExit(installInterfaceCall, astarteAPIClient)
+
 	installInterfaceRes, err := installInterfaceCall.Run(astarteAPIClient)
 	if err != nil {
 		return err
@@ -364,6 +391,12 @@ func updateInterface(realm string, interfaceName string, interfaceMajor int, new
 	if err != nil {
 		return err
 	}
+
+	// When we're here in the context of `interfaces sync`, the to-curl flag
+	// is always false (`interfaces sync` has no `--to-curl` flag)
+	// and thus the call will never exit unexpectedly
+	utils.MaybeCurlAndExit(updateInterfaceCall, astarteAPIClient)
+
 	updateInterfaceRes, err := updateInterfaceCall.Run(astarteAPIClient)
 	if err != nil {
 		return err

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -44,6 +44,8 @@ func init() {
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	RealmManagementCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
+	RealmManagementCmd.PersistentFlags().Bool("to-curl", false, "When set, display a command-line equivalent instead of running the command.")
+	viper.BindPFlag("realmmanagement-to-curl", RealmManagementCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
@@ -61,6 +63,9 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	if realm == "" {
 		return errors.New("realm is required")
 	}
+
+	// if just --to-curl is given, default to true
+	cmd.Flags().Lookup("to-curl").NoOptDefVal = "true"
 
 	return nil
 }

--- a/cmd/realm/triggers.go
+++ b/cmd/realm/triggers.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/astarte-platform/astartectl/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -86,6 +87,9 @@ func triggersListF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(realmTriggersCall, astarteAPIClient)
+
 	realmTriggersRes, err := realmTriggersCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -105,6 +109,9 @@ func triggersShowF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(getTriggerCall, astarteAPIClient)
+
 	getTriggerRes, err := getTriggerCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -135,6 +142,9 @@ func triggersInstallF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(installTriggerCall, astarteAPIClient)
+
 	installTriggerRes, err := installTriggerCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -154,6 +164,9 @@ func triggersDeleteF(command *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
+
+	utils.MaybeCurlAndExit(deleteTriggerCall, astarteAPIClient)
+
 	deleteTriggerRes, err := deleteTriggerCall.Run(astarteAPIClient)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/utils/cmdline.go
+++ b/utils/cmdline.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/astarte-platform/astarte-go/client"
+	"github.com/spf13/viper"
 )
 
 // AskForConfirmation asks the user if he wants to continue.
@@ -69,4 +72,15 @@ func PromptChoice(question string, defaultValue string, allowEmpty, nonInteracti
 
 		return response, nil
 	}
+}
+
+func MaybeCurlAndExit(req client.AstarteRequest, client *client.Client) {
+	if ShouldCurl() {
+		fmt.Println(req.ToCurl(client))
+		os.Exit(0)
+	}
+}
+
+func ShouldCurl() bool {
+	return viper.GetBool("appengine-to-curl") || viper.GetBool("housekeeping-to-curl") || viper.GetBool("pairing-to-curl") || viper.GetBool("realmmanagement-to-curl")
 }


### PR DESCRIPTION
Add the `--to-curl` flag to allow the user to get a bash command equivalent to the one astartectl would run.
If the flag is set, astartectl will take no futher action.
Closes #100.