### PR TITLE
`appengine devices send-data`: correctly parse integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for ignoring SSL errors while interacting with the Astarte APIs.
 
+### Fixed
+- `appengine devices send-data` correctly parses integers as int32 instead of in64.
+  Fix [#176](https://github.com/astarte-platform/astartectl/issues/176).
+
 ## [22.11.00] - 2022-12-06
 ### Added
 - `cluster instances migrate storage-version` allows to migrate CRDs with `[v1alpha1, v1alpha2]`

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -1084,7 +1084,13 @@ func parseSendDataPayload(payload string, mappingType interfaces.AstarteMappingT
 		if ret, err = strconv.ParseFloat(payload, 64); err != nil {
 			return nil, err
 		}
-	case interfaces.Integer, interfaces.LongInteger:
+	case interfaces.Integer:
+		val, err := strconv.ParseInt(payload, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		ret = int32(val)
+	case interfaces.LongInteger:
 		if ret, err = strconv.ParseInt(payload, 10, 64); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Parse integers as int32 and longintegers as int64.
Close #176.