### PR TITLE
appengine device get-samples: fix since param

### DIFF
--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -746,7 +746,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	sinceTime := time.Unix(0, 0)
+	sinceTime := time.Time{}
 	if since != "" {
 		sinceTime, err = dateparse.ParseLocal(since)
 		if err != nil {


### PR DESCRIPTION
Do not fail when the since param is not specified.