### PR TITLE
`appengine:` check if RM URL is set when auxiliary queries may be used

### DIFF
--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -1083,7 +1083,7 @@ func shouldSkipRealmManagementChecks(cmd cobra.Command) (bool, error) {
 	}
 
 	// skip RM checks if explicitly requested, or if RM service is not set
-	if skipRealmManagementChecks {
+	if skipRealmManagementChecks || astarteAPIClient.GetRealmManagementURL() == nil {
 		return true, nil
 	} else {
 		token, err := cmd.Flags().GetString("token")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5
+	github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGL
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5 h1:b+Yux7iQsneSXP82cfF+p+4v8hAEhaKWKMI07olbypE=
 github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d h1:LDxyknict/zKsND1jsYYueuyAZxLaje1ieyG25xmOTg=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5 h1:b+Yux7iQsneSXP82cfF+p+4v8hAEhaKWKMI07olbypE=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230222145819-6424c756eaa5/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
 github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d h1:LDxyknict/zKsND1jsYYueuyAZxLaje1ieyG25xmOTg=
 github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/utils/client.go
+++ b/utils/client.go
@@ -122,20 +122,21 @@ func setupURLs(individualURLVariables map[astarteservices.AstarteService]string)
 	return ret, nil
 }
 
-func setupIndividualURLs(individualURLVariables map[astarteservices.AstarteService]string) []client.Option {
+func setupIndividualURLs(individualURLs map[astarteservices.AstarteService]string) []client.Option {
 	var ret = []client.Option{}
-	switch {
-	case individualURLVariables[astarteservices.Housekeeping] != "":
-		ret = append(ret, client.WithHousekeepingURL(individualURLVariables[astarteservices.Housekeeping]))
-		fallthrough
-	case individualURLVariables[astarteservices.AppEngine] != "":
-		ret = append(ret, client.WithAppEngineURL(individualURLVariables[astarteservices.AppEngine]))
-		fallthrough
-	case individualURLVariables[astarteservices.Pairing] != "":
-		ret = append(ret, client.WithPairingURL(individualURLVariables[astarteservices.Pairing]))
-		fallthrough
-	case individualURLVariables[astarteservices.RealmManagement] != "":
-		ret = append(ret, client.WithRealmManagementURL(individualURLVariables[astarteservices.RealmManagement]))
+
+	// Golang I hate you
+	if individualURLs[astarteservices.Housekeeping] != "" {
+		ret = append(ret, client.WithHousekeepingURL(individualURLs[astarteservices.Housekeeping]))
+	}
+	if individualURLs[astarteservices.AppEngine] != "" {
+		ret = append(ret, client.WithAppEngineURL(individualURLs[astarteservices.AppEngine]))
+	}
+	if individualURLs[astarteservices.Pairing] != "" {
+		ret = append(ret, client.WithPairingURL(individualURLs[astarteservices.Pairing]))
+	}
+	if individualURLs[astarteservices.RealmManagement] != "" {
+		ret = append(ret, client.WithRealmManagementURL(individualURLs[astarteservices.RealmManagement]))
 	}
 	return ret
 }


### PR DESCRIPTION
If RM URL is not set, do not try to perform auxiliary queries, even if `--skip-realm-management` is not explicitly set.
Contextually, bump astarte-go to the latest version, as it exposes a method for retrieving the URL.