### PR TITLE
Fix appengine data-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
 ## [22.11.02] - Unreleased
 ### Changed
 - `appengine device`: print a parametric command rather than a partial one with
   `--to-curl`when multiple API calls are involved (e.g. `send-data`).
+
+### Fixed
+- `appengine data-snapshot` properly gathers and shows data snapshots from a device.
 
 ## [22.11.01] - 2023-03-15
 ### Added
 - Add support for ignoring SSL errors while interacting with the Astarte APIs.
 - Add the `--to-curl` flag to print a command-line equivalent of a command instead
   of running it.
+
 ### Changed
 - `cluster instance deploy`: Astarte >= `v1.0.0` is deployed using the
   `api.astarte-platform.org/v1alpha2` API.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d
+	github.com/astarte-platform/astarte-go v0.90.5-0.20230323110518-62761dbc87f2
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d h1:LDxyknict/zKsND1jsYYueuyAZxLaje1ieyG25xmOTg=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230309151903-983400c3076d/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230323110518-62761dbc87f2 h1:wXwbDzGktjvdtaUIG/yC9VmL35SIIiwNCKfak/idy1w=
+github.com/astarte-platform/astarte-go v0.90.5-0.20230323110518-62761dbc87f2/go.mod h1:h5Kmuogn6yDrclFQmbbau+rX6pkOblF9gnyhIFTGw1w=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
- bump astarte-go dependency
- allow users to properly retrieve data snapshots