### PR TITLE
Context: Stop warning about missing configuration, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - `appengine data-snapshot` properly gathers and shows data snapshots from a device.
+- context: do not warn when config is missing. Users will have to provide parameters by hand.
 
 ## [22.11.01] - 2023-03-15
 ### Added

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/astarte-platform/astartectl/cmd/appengine"
@@ -96,9 +95,11 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	// If the config does not exist, do not warn - it's simply not there.
-	if err := config.ConfigureViper(cfgContext); err != nil && reflect.TypeOf(viper.ConfigFileNotFoundError{}) != reflect.TypeOf(err) {
-		fmt.Fprintf(os.Stderr, "warn: Error while loading configuration: %s\n", err.Error())
+	if err := config.ConfigureViper(cfgContext); err != nil {
+		// If the config does not exist, do not warn - it's simply not there.
+		if _, ok := err.(*os.PathError); !ok {
+			fmt.Fprintf(os.Stderr, "warn: Error while loading configuration: %s\n", err.Error())
+		}
 	}
 
 	replacer := strings.NewReplacer(".", "_")


### PR DESCRIPTION
If a config file is missing, the user will have to provide parameters by hand. This was the expected interaction, but a(nother) change in the viper library made astartectl always show a noisy `error while loading configuration` warning.
Related to #178.