### PR TITLE
Fix appengine devices list

### DIFF
--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -240,7 +240,7 @@ func devicesListF(command *cobra.Command, args []string) error {
 }
 
 func printSimpleDevicesList(realm string) {
-	paginator, err := astarteAPIClient.GetDeviceListPaginator(realm, 100, client.DeviceDetailsFormat)
+	paginator, err := astarteAPIClient.GetDeviceListPaginator(realm, 100, client.DeviceIDFormat)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
When device details are not required, do not request them. Then, the parsing can take care of properly rendering the list of devices.