### PR TITLE
`devices send-data`: make it clear if an interface is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `appengine device`: print a parametric command rather than a partial one with
   `--to-curl`when multiple API calls are involved (e.g. `send-data`).
+- `appengine device send-data` returns a clear error when an interface is not found.
+  See [#132](https://github.com/astarte-platform/astartectl/issues/132).
 
 ### Fixed
 - `appengine data-snapshot` properly gathers and shows data snapshots from a device.

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -1148,6 +1148,7 @@ func getProtoInterface(deviceID string, deviceIdentifierType client.DeviceIdenti
 			return iface, err
 		}
 
+		found := false
 		for astarteInterface, interfaceIntrospection := range deviceDetails.Introspection {
 			if astarteInterface != interfaceName {
 				continue
@@ -1160,10 +1161,13 @@ func getProtoInterface(deviceID string, deviceIdentifierType client.DeviceIdenti
 				// Die here, given we really can't recover further
 				return iface, err
 			}
+			found = true
 			break
 		}
+		if !found {
+			return iface, fmt.Errorf("interface %s not found in device introspection", interfaceName)
+		}
 	}
-
 	return iface, nil
 }
 


### PR DESCRIPTION
`getProtoInterface` did not return anything meaningful if a given interface was not present in the device introspection. Do it.
Close #132 .