### PR TITLE
Install and update interfaces are now synchronous.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `realm-management interfaces {install,upgrade}` commands are run synchronously.
 
 ## [22.11.02] - 23/05/2023
 ### Changed

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -367,7 +367,7 @@ func getInterfaceDefinition(realm, interfaceName string, interfaceMajor int) (in
 }
 
 func installInterface(realm string, iface interfaces.AstarteInterface) error {
-	installInterfaceCall, err := astarteAPIClient.InstallInterface(realm, iface)
+	installInterfaceCall, err := astarteAPIClient.InstallInterface(realm, iface, true)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func installInterface(realm string, iface interfaces.AstarteInterface) error {
 }
 
 func updateInterface(realm string, interfaceName string, interfaceMajor int, newInterface interfaces.AstarteInterface) error {
-	updateInterfaceCall, err := astarteAPIClient.UpdateInterface(realm, interfaceName, interfaceMajor, newInterface)
+	updateInterfaceCall, err := astarteAPIClient.UpdateInterface(realm, interfaceName, interfaceMajor, newInterface, true)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.90.5-0.20230522073615-9c590d8a9ff6
+	github.com/astarte-platform/astarte-go v0.91.0
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230522073615-9c590d8a9ff6 h1:7zEWr8mTVoA31rjBj5dACag1YCccDyD1yzao9UjXrp8=
-github.com/astarte-platform/astarte-go v0.90.5-0.20230522073615-9c590d8a9ff6/go.mod h1:6e/IkwjAS7fXdCerA/xr/Fcv6OseNRhDFytuhCGfjvM=
+github.com/astarte-platform/astarte-go v0.91.0 h1:VEsTKfyEDxFzKOQLcgS9HHPiiC0p5eMkj+luSiQ3AwE=
+github.com/astarte-platform/astarte-go v0.91.0/go.mod h1:6e/IkwjAS7fXdCerA/xr/Fcv6OseNRhDFytuhCGfjvM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Contextually, bump astarte-go to v0.91.0.

This PR addresses #192.