### PR TITLE
`send-data`: fix curl representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [22.11.03] - Unreleased
+### Fixed
+- `appengine device send-data`: fix `--to-curl` representation to return a valid command.
+
 ## [22.11.02] - 23/05/2023
 ### Changed
 - `appengine device`: print a parametric command rather than a partial one with

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -54,7 +54,7 @@ const (
 	-H "User-Agent: astarte-go" \
 	-H "Authorization: Bearer $TOKEN" \
 	"https://$ASTARTE_BASE_URL/appengine/v1/$REALM/devices/$DEVICE_ID/interfaces/$INTERFACE/$PATH
-	-data '{"data" : $DATA}'`
+	--data '{"data" : $DATA}'`
 )
 
 // DevicesCmd represents the devices command


### PR DESCRIPTION
A missing '-' made the command invalid. Add it.