### PR TITLE
Add `realm-management interfaces save` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add fish shell completions generator command
+- `realm-management interfaces save` allows to save interfaces to disk.
 
 ### Changed
 - `realm-management interfaces {install,upgrade}` commands are run synchronously.


### PR DESCRIPTION
The command allows to save each interface in a realm to disk.

Fix #207.