### PR TITLE
Why not a linter?

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,32 @@
+# Copyright © 2023 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Static code checking"
+on:
+  pull_request:
+  push:
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+    # Since v3, golangci-lint needs explicit go-setup
+    - uses: actions/setup-go@v4
+      with:
+        go-version: v1.20.x
+    # Run golint-ci
+    - uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.53

--- a/cmd/appengine/appengine.go
+++ b/cmd/appengine/appengine.go
@@ -41,22 +41,22 @@ var astarteAPIClient *client.Client
 func init() {
 	AppEngineCmd.PersistentFlags().StringP("realm-key", "k", "",
 		"Path to realm private key used to generate JWT for authentication")
-	AppEngineCmd.MarkPersistentFlagFilename("realm-key")
+	_ = AppEngineCmd.MarkPersistentFlagFilename("realm-key")
 	AppEngineCmd.PersistentFlags().String("appengine-url", "",
 		"AppEngine API base URL. Defaults to <astarte-url>/appengine.")
-	viper.BindPFlag("individual-urls.appengine", AppEngineCmd.PersistentFlags().Lookup("appengine-url"))
+	_ = viper.BindPFlag("individual-urls.appengine", AppEngineCmd.PersistentFlags().Lookup("appengine-url"))
 	AppEngineCmd.PersistentFlags().String("realm-management-url", "",
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	AppEngineCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
 	AppEngineCmd.PersistentFlags().Bool("to-curl", false,
 		"When set, display a command-line equivalent instead of running the command.")
-	viper.BindPFlag("appengine-to-curl", AppEngineCmd.PersistentFlags().Lookup("to-curl"))
+	_ = viper.BindPFlag("appengine-to-curl", AppEngineCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 	appEngineURLOverride := viper.GetString("individual-urls.appengine")
-	viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
+	_ = viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
 	realmManagementURLOverride := viper.GetString("individual-urls.realm-management")
 	// Handle a special failure case, if realm-management is provided but appengine isn't
 	if appEngineURLOverride == "" && realmManagementURLOverride != "" {
@@ -68,14 +68,14 @@ func appEnginePersistentPreRunE(cmd *cobra.Command, args []string) error {
 		astarteservices.RealmManagement: "individual-urls.realm-management",
 	}
 
-	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
+	_ = viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(individualURLVariables, "realm.key", "realm.key-file")
 	if err != nil {
 		return err
 	}
 
-	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
+	_ = viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
 	realm = viper.GetString("realm.name")
 	if realm == "" {
 		return errors.New("realm is required")

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -266,9 +266,7 @@ func printSimpleDevicesList(realm string) {
 		rawPage, _ := deviceListRes.Parse()
 		page, _ := rawPage.([]string)
 
-		for _, deviceID := range page {
-			deviceIDList = append(deviceIDList, deviceID)
-		}
+		deviceIDList = append(deviceIDList, page...)
 	}
 
 	fmt.Println(deviceIDList)
@@ -857,10 +855,8 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				os.Exit(1)
 			}
 
-			switch rawPage.(type) {
+			switch page := rawPage.(type) {
 			case []client.DatastreamIndividualValue:
-				page, _ := rawPage.([]client.DatastreamIndividualValue)
-
 				// Go with the table header regardless of the requested output type
 				t.AppendHeader(table.Row{"Timestamp", "Value"})
 
@@ -880,8 +876,6 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				renderOutput(t, sliceAcc, outputType)
 
 			case map[string]client.DatastreamIndividualValue:
-				page, _ := rawPage.(map[string]client.DatastreamIndividualValue)
-
 				// Go with the table header regardless of the requested output type
 				t.AppendHeader(table.Row{"Path", "Timestamp", "Value"})
 
@@ -926,12 +920,10 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				os.Exit(1)
 			}
 
-			switch rawPage.(type) {
+			switch page := rawPage.(type) {
 			case []client.DatastreamObjectValue:
 				headerRow := table.Row{"Timestamp"}
 				headerPrinted := false
-
-				page, _ := rawPage.([]client.DatastreamObjectValue)
 
 				for _, v := range page {
 					if outputType != "json" {
@@ -968,8 +960,6 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 			case map[string][]client.DatastreamObjectValue:
 				headerRow := table.Row{"Base path", "Timestamp"}
 				headerPrinted := false
-
-				page, _ := rawPage.(map[string][]client.DatastreamObjectValue)
 
 				keys := []string{}
 				for k, v := range page {

--- a/cmd/appengine/groups.go
+++ b/cmd/appengine/groups.go
@@ -206,9 +206,7 @@ func groupsDevicesListF(command *cobra.Command, args []string) error {
 
 		rawDevices, _ := deviceListRes.Parse()
 		devices, _ := rawDevices.([]string)
-		for _, v := range devices {
-			deviceList = append(deviceList, v)
-		}
+		deviceList = append(deviceList, devices...)
 	}
 
 	fmt.Println(deviceList)

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -59,10 +59,6 @@ var (
 	kubernetesAPIExtensionsClient *apiextensions.Clientset
 	kubernetesDynamicClient       dynamic.Interface
 
-	astarteGroupResource = schema.GroupResource{
-		Group:    "api.astarte-platform.org",
-		Resource: "Astarte",
-	}
 	astarteV1Alpha1 = schema.GroupVersionResource{
 		Group:    "api.astarte-platform.org",
 		Version:  "v1alpha1",
@@ -83,11 +79,6 @@ var (
 		Version:  "v1alpha1",
 		Resource: "astartedefaultingresses",
 	}
-	crdResource = schema.GroupVersionResource{
-		Group:    "apiextensions.k8s.io",
-		Version:  "v1beta1",
-		Resource: "customresourcedefinitions",
-	}
 	astarteOperatorVersions = map[string]schema.GroupVersionResource{
 		"v1alpha1": astarteV1Alpha1,
 		"v1alpha2": astarteV1Alpha2,
@@ -105,7 +96,7 @@ func init() {
 
 	ClusterCmd.PersistentFlags().StringP("kubeconfig", "k", defaultKubeconfigPath,
 		"(optional) absolute path to the kubeconfig file")
-	viper.BindPFlag("kubeconfig", ClusterCmd.PersistentFlags().Lookup("kubeconfig"))
+	_ = viper.BindPFlag("kubeconfig", ClusterCmd.PersistentFlags().Lookup("kubeconfig"))
 
 	// Add flags which are common to all instances commands
 	InstancesCmd.PersistentFlags().StringP("namespace", "n", "astarte", "Namespace of the Astarte resource. Defaults to 'astarte'")

--- a/cmd/cluster/instance_destroy.go
+++ b/cmd/cluster/instance_destroy.go
@@ -69,7 +69,7 @@ func clusterDestroyF(command *cobra.Command, args []string) error {
 
 	fmt.Printf("Will destroy Astarte instance %s in namespace %s.\n", resourceName, resourceNamespace)
 	fmt.Println("WARNING: This operation is NOT REVERSIBLE and ALL DATA WILL BE LOST!!!")
-	confirmation, err := utils.PromptChoice("To continue, please enter the exact name of the Astarte instance you are deleting:", "", true, y)
+	confirmation, _ := utils.PromptChoice("To continue, please enter the exact name of the Astarte instance you are deleting:", "", true, y)
 	if confirmation != resourceName {
 		fmt.Fprintln(os.Stderr, "Aborting.")
 		os.Exit(1)

--- a/cmd/cluster/utils.go
+++ b/cmd/cluster/utils.go
@@ -15,7 +15,6 @@
 package cluster
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -37,52 +36,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
 )
 
 func init() {
 	apiextensions.Install(scheme.Scheme)
-}
-
-func unmarshalYAML(res string, version string) runtime.Object {
-	content, err := getOperatorContent(res, version)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	decode := scheme.Codecs.UniversalDeserializer().Decode
-	obj, _, err := decode([]byte(content), nil, nil)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-
-	return obj
-}
-
-func runtimeObjectToJSON(object runtime.Object) ([]byte, error) {
-	serializer := jsonserializer.NewSerializer(jsonserializer.DefaultMetaFactory, scheme.Scheme, scheme.Scheme, false)
-	buffer := bytes.NewBuffer([]byte{})
-	err := serializer.Encode(object, buffer)
-	return buffer.Bytes(), err
-}
-
-func unmarshalOperatorContentYAMLToJSON(res string, version string) map[string]interface{} {
-	content, err := getOperatorContent(res, version)
-	jsonStruct, err := utils.UnmarshalYAMLToJSON([]byte(content))
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Error while parsing Kubernetes Resources. Your deployment might be incomplete.")
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	return jsonStruct
 }
 
 func listAstartes(namespace string) (map[string]*unstructured.UnstructuredList, error) {
@@ -139,16 +98,8 @@ func getHousekeepingKey(name, namespace string, checkFirst bool) ([]byte, error)
 	return secret.Data["private-key"], nil
 }
 
-func getAstarte(astarteCRD dynamic.NamespaceableResourceInterface, name string, namespace string) (*unstructured.Unstructured, error) {
-	return astarteCRD.Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
-}
-
 func getAstarteOperator(operatorName, operatorNamespace string) (*appsv1.Deployment, error) {
 	return kubernetesClient.AppsV1().Deployments(operatorNamespace).Get(context.TODO(), operatorName, metav1.GetOptions{})
-}
-
-func getLastOperatorRelease() (string, error) {
-	return getLastReleaseForAstarteRepo("astarte-kubernetes-operator")
 }
 
 func getLastAstarteRelease() (string, error) {
@@ -181,30 +132,6 @@ func getLastReleaseForAstarteRepo(repo string) (string, error) {
 	sort.Sort(collection)
 
 	return collection[len(collection)-1].Original(), nil
-}
-
-func getOperatorContent(path string, tag string) (string, error) {
-	return getContentFromAstarteRepo("astarte-kubernetes-operator", path, tag)
-}
-
-func getContentFromAstarteRepo(repo string, path string, tag string) (string, error) {
-	ctx := context.Background()
-	client := github.NewClient(nil)
-
-	ref := "v" + tag
-	if strings.Contains(tag, "-snapshot") {
-		// In this case, we want to fetch from the latest release branch.
-		ref = "release-" + strings.Replace(tag, "-snapshot", "", -1)
-	}
-
-	content, _, _, err := client.Repositories.GetContents(ctx, "astarte-platform", repo,
-		path, &github.RepositoryContentGetOptions{Ref: ref})
-
-	if err != nil {
-		return "", nil
-	}
-
-	return content.GetContent()
 }
 
 func getClusterAllocatableResources() (int, int64, int64, error) {
@@ -259,86 +186,6 @@ func getManagedAstarteResourceStatus(res unstructured.Unstructured) (string, str
 
 func isUnstableVersion(version string) bool {
 	return strings.HasSuffix(version, "-snapshot") || version == "snapshot"
-}
-
-func getBaseVersionFromUnstable(version string) (string, error) {
-	if !isUnstableVersion(version) {
-		return "", fmt.Errorf("%v is not an unstable version", version)
-	}
-
-	if version == "snapshot" {
-		return "", errors.New("You are running on snapshot - I have no way of reconciling you from here")
-	}
-
-	// Get the base version, and add a .0.
-	baseVersion := strings.Replace(version, "-snapshot", "", 1)
-	baseVersion += ".0"
-
-	return baseVersion, nil
-}
-
-func promptForProfileExcluding(command *cobra.Command, astarteVersion *semver.Version, excluding []string) (string, deployment.AstarteClusterProfile, error) {
-	nodes, allocatableCPU, allocatableMemory, err := getClusterAllocatableResources()
-	if err != nil {
-		return "", deployment.AstarteClusterProfile{}, err
-	}
-
-	fmt.Printf("Cluster has %v nodes\n", nodes)
-	fmt.Printf("Allocatable CPU is %vm\n", allocatableCPU)
-	fmt.Printf("Allocatable Memory is %v\n", bytefmt.ByteSize(uint64(allocatableMemory)))
-	fmt.Println()
-
-	clusterRequirements := deployment.AstarteProfileRequirements{
-		CPUAllocation:    allocatableCPU,
-		MemoryAllocation: allocatableMemory,
-		MinNodes:         nodes,
-		MaxNodes:         nodes,
-	}
-	availableProfiles := deployment.GetProfilesForVersionAndRequirements(astarteVersion, clusterRequirements)
-
-	if len(availableProfiles) == 0 {
-		return "", deployment.AstarteClusterProfile{}, fmt.Errorf("Unfortunately, your cluster allocatable resources do not allow for any profile to be deployed")
-	}
-
-	unexcludedAvailableProfiles := map[string]deployment.AstarteClusterProfile{}
-	// Handle exclusion list
-	for k, v := range availableProfiles {
-		exclude := false
-		for _, s := range excluding {
-			if s == k {
-				exclude = true
-				break
-			}
-		}
-		if exclude {
-			continue
-		}
-
-		unexcludedAvailableProfiles[k] = v
-	}
-
-	if len(unexcludedAvailableProfiles) == 0 {
-		return "", deployment.AstarteClusterProfile{}, fmt.Errorf("There are no other profiles which can be deployed on this cluster besides %s", excluding)
-	}
-
-	fmt.Println("You can safely deploy the following Profiles on this cluster:")
-	for _, v := range unexcludedAvailableProfiles {
-		fmt.Printf("%s: %s\n", v.Name, v.Description)
-	}
-
-	fmt.Println()
-	profile := getStringFlagFromPromptOrDie(command, "profile", "Which profile would you like to deploy?", "", false)
-
-	if _, ok := unexcludedAvailableProfiles[profile]; !ok {
-		fmt.Fprintf(os.Stderr, "Profile %s does not exist! Aborting.\n", profile)
-		os.Exit(1)
-	}
-
-	return profile, availableProfiles[profile], nil
-}
-
-func promptForProfile(command *cobra.Command, astarteVersion *semver.Version) (string, deployment.AstarteClusterProfile, error) {
-	return promptForProfileExcluding(command, astarteVersion, []string{})
 }
 
 func getProfile(command *cobra.Command, astarteVersion *semver.Version, burst bool) (string, deployment.AstarteClusterProfile, error) {

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -40,7 +40,7 @@ To configure your bash shell to load completions for each session add to your .b
 source ~/bash_completion.d/astartectl
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenBashCompletion(os.Stdout)
+		_ = rootCmd.GenBashCompletion(os.Stdout)
 	},
 }
 
@@ -54,7 +54,7 @@ astartectl completion zsh > ~/.zsh/completion/_astartectl
 autoload -U compinit && compinit
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenZshCompletion(os.Stdout)
+		_ = rootCmd.GenZshCompletion(os.Stdout)
 	},
 }
 
@@ -67,7 +67,7 @@ To setup your completions, run
 astartectl completion fish > ~/.config/fish/completions/astartectl.fish
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		rootCmd.GenFishCompletion(os.Stdout, true)
+		_ = rootCmd.GenFishCompletion(os.Stdout, true)
 	},
 }
 

--- a/cmd/config/clusters.go
+++ b/cmd/config/clusters.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/tabwriter"
 
@@ -224,7 +223,7 @@ func clustersGetHousekeepingKeyF(command *cobra.Command, args []string) error {
 
 	if output != "" {
 		// Save to file
-		if err := ioutil.WriteFile(output, decoded, 0644); err != nil {
+		if err := os.WriteFile(output, decoded, 0644); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -348,7 +347,7 @@ func performClusterCreation(clusterName string, isUpdate bool, command *cobra.Co
 		}
 	}
 	if housekeepingKey != "" {
-		contents, err := ioutil.ReadFile(housekeepingKey)
+		contents, err := os.ReadFile(housekeepingKey)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/cmd/config/contexts.go
+++ b/cmd/config/contexts.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/tabwriter"
 
@@ -224,7 +223,7 @@ func contextsGetRealmKeyF(command *cobra.Command, args []string) error {
 
 	if output != "" {
 		// Save to file
-		if err := ioutil.WriteFile(output, decoded, 0644); err != nil {
+		if err := os.WriteFile(output, decoded, 0644); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
@@ -322,7 +321,7 @@ func performContextCreation(contextName string, isUpdate bool, command *cobra.Co
 		context.Realm.Name = realmName
 	}
 	if realmPrivateKey != "" {
-		contents, err := ioutil.ReadFile(realmPrivateKey)
+		contents, err := os.ReadFile(realmPrivateKey)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/cmd/config/import_export.go
+++ b/cmd/config/import_export.go
@@ -17,7 +17,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/astarte-platform/astartectl/config"
@@ -75,7 +74,7 @@ func configImportF(command *cobra.Command, args []string) error {
 	}
 
 	// First of all, read the file content
-	contents, err := ioutil.ReadFile(args[0])
+	contents, err := os.ReadFile(args[0])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -129,7 +128,7 @@ func configExportF(command *cobra.Command, args []string) error {
 	if output == "" {
 		fmt.Println(string(jsonBytes))
 	} else {
-		if err := ioutil.WriteFile(output, jsonBytes, 0644); err != nil {
+		if err := os.WriteFile(output, jsonBytes, 0644); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}

--- a/cmd/housekeeping/housekeeping.go
+++ b/cmd/housekeeping/housekeeping.go
@@ -36,14 +36,14 @@ var astarteAPIClient *client.Client
 func init() {
 	HousekeepingCmd.PersistentFlags().StringP("housekeeping-key", "k", "",
 		"Path to housekeeping private key to generate JWT for authentication")
-	HousekeepingCmd.MarkPersistentFlagFilename("housekeeping-key")
-	viper.BindPFlag("housekeeping.key-file", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-key"))
+	_ = HousekeepingCmd.MarkPersistentFlagFilename("housekeeping-key")
+	_ = viper.BindPFlag("housekeeping.key-file", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-key"))
 	HousekeepingCmd.PersistentFlags().String("housekeeping-url", "",
 		"Housekeeping API base URL. Defaults to <astarte-url>/housekeeping.")
-	viper.BindPFlag("individual-urls.housekeeping", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-url"))
+	_ = viper.BindPFlag("individual-urls.housekeeping", HousekeepingCmd.PersistentFlags().Lookup("housekeeping-url"))
 	HousekeepingCmd.PersistentFlags().Bool("to-curl", false,
 		"When set, display a command-line equivalent instead of running the command.")
-	viper.BindPFlag("housekeeping-to-curl", HousekeepingCmd.PersistentFlags().Lookup("to-curl"))
+	_ = viper.BindPFlag("housekeeping-to-curl", HousekeepingCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func housekeepingPersistentPreRunE(cmd *cobra.Command, args []string) error {

--- a/cmd/housekeeping/realms.go
+++ b/cmd/housekeeping/realms.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strconv"
@@ -266,13 +265,13 @@ func realmsCreateF(command *cobra.Command, args []string) error {
 	var privateKeyContent []byte
 	switch {
 	case publicKey != "":
-		publicKeyContent, err = ioutil.ReadFile(publicKey)
+		publicKeyContent, err = os.ReadFile(publicKey)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	case privateKey != "":
-		privateKeyContent, err = ioutil.ReadFile(privateKey)
+		privateKeyContent, err = os.ReadFile(privateKey)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/cmd/pairing/pairing.go
+++ b/cmd/pairing/pairing.go
@@ -38,19 +38,19 @@ var astarteAPIClient *client.Client
 func init() {
 	PairingCmd.PersistentFlags().StringP("realm-key", "k", "",
 		"Path to realm private key used to generate JWT for authentication")
-	PairingCmd.MarkPersistentFlagFilename("realm-key")
+	_ = PairingCmd.MarkPersistentFlagFilename("realm-key")
 	PairingCmd.PersistentFlags().String("pairing-url", "",
 		"Pairing API base URL. Defaults to <astarte-url>/pairing.")
-	viper.BindPFlag("individual-urls.pairing", PairingCmd.PersistentFlags().Lookup("pairing-url"))
+	_ = viper.BindPFlag("individual-urls.pairing", PairingCmd.PersistentFlags().Lookup("pairing-url"))
 	PairingCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
 	PairingCmd.PersistentFlags().Bool("to-curl", false,
 		"When set, display a command-line equivalent instead of running the command.")
-	viper.BindPFlag("pairing-to-curl", PairingCmd.PersistentFlags().Lookup("to-curl"))
+	_ = viper.BindPFlag("pairing-to-curl", PairingCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
+	_ = viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(
 		map[astarteservices.AstarteService]string{astarteservices.Pairing: "individual-urls.pairing"}, "realm.key", "realm.key-file")
@@ -58,7 +58,7 @@ func pairingPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
+	_ = viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
 	realm = viper.GetString("realm.name")
 	if realm == "" {
 		return errors.New("realm is required")

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -17,7 +17,6 @@ package realm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -185,7 +184,7 @@ func interfacesShowF(command *cobra.Command, args []string) error {
 }
 
 func interfacesInstallF(command *cobra.Command, args []string) error {
-	interfaceFile, err := ioutil.ReadFile(args[0])
+	interfaceFile, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}
@@ -229,7 +228,7 @@ func interfacesDeleteF(command *cobra.Command, args []string) error {
 }
 
 func interfacesUpdateF(command *cobra.Command, args []string) error {
-	interfaceFile, err := ioutil.ReadFile(args[0])
+	interfaceFile, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}
@@ -260,7 +259,7 @@ Install or update your interfaces one by one with 'interfaces install' or 'inter
 	interfacesToUpdate := []interfaces.AstarteInterface{}
 
 	for _, f := range args {
-		interfaceFile, err := ioutil.ReadFile(f)
+		interfaceFile, err := os.ReadFile(f)
 		if err != nil {
 			return err
 		}

--- a/cmd/realm/realm.go
+++ b/cmd/realm/realm.go
@@ -39,18 +39,18 @@ var astarteAPIClient *client.Client
 func init() {
 	RealmManagementCmd.PersistentFlags().StringP("realm-key", "k", "",
 		"Path to realm private key used to generate JWT for authentication")
-	RealmManagementCmd.MarkPersistentFlagFilename("realm-key")
+	_ = RealmManagementCmd.MarkPersistentFlagFilename("realm-key")
 	RealmManagementCmd.PersistentFlags().String("realm-management-url", "",
 		"Realm Management API base URL. Defaults to <astarte-url>/realmmanagement.")
 	RealmManagementCmd.PersistentFlags().StringP("realm-name", "r", "",
 		"The name of the realm that will be queried")
 	RealmManagementCmd.PersistentFlags().Bool("to-curl", false, "When set, display a command-line equivalent instead of running the command.")
-	viper.BindPFlag("realmmanagement-to-curl", RealmManagementCmd.PersistentFlags().Lookup("to-curl"))
+	_ = viper.BindPFlag("realmmanagement-to-curl", RealmManagementCmd.PersistentFlags().Lookup("to-curl"))
 }
 
 func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
-	viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
-	viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
+	_ = viper.BindPFlag("individual-urls.realm-management", cmd.Flags().Lookup("realm-management-url"))
+	_ = viper.BindPFlag("realm.key-file", cmd.Flags().Lookup("realm-key"))
 	var err error
 	astarteAPIClient, err = utils.APICommandSetup(
 		map[astarteservices.AstarteService]string{astarteservices.RealmManagement: "individual-urls.realm-management"}, "realm.key", "realm.key-file")
@@ -58,7 +58,7 @@ func realmManagementPersistentPreRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
+	_ = viper.BindPFlag("realm.name", cmd.Flags().Lookup("realm-name"))
 	realm = viper.GetString("realm.name")
 	if realm == "" {
 		return errors.New("realm is required")

--- a/cmd/realm/triggers.go
+++ b/cmd/realm/triggers.go
@@ -17,7 +17,6 @@ package realm
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/astarte-platform/astartectl/utils"
@@ -126,7 +125,7 @@ func triggersShowF(command *cobra.Command, args []string) error {
 }
 
 func triggersInstallF(command *cobra.Command, args []string) error {
-	triggerFile, err := ioutil.ReadFile(args[0])
+	triggerFile, err := os.ReadFile(args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -53,14 +53,6 @@ The keypair will be saved in the current directory with names <realm_name>_priva
 	RunE:    genKeypairF,
 }
 
-var jwtTypesToClaim = map[string]string{
-	"housekeeping":     "a_ha",
-	"realm-management": "a_rma",
-	"pairing":          "a_pa",
-	"appengine":        "a_aea",
-	"channels":         "a_ch",
-}
-
 var jwtTypes = []string{"housekeeping", "realm-management", "pairing", "appengine", "channels"}
 
 var genJwtCmd = &cobra.Command{
@@ -127,7 +119,7 @@ Astarte specific token claims are:
 func init() {
 	genJwtCmd.Flags().StringP("private-key", "k", "", `Path to PEM encoded private key.
 Should be Housekeeping key to generate an housekeeping token, Realm key for everything else.`)
-	genJwtCmd.MarkFlagFilename("private-key")
+	_ = genJwtCmd.MarkFlagFilename("private-key")
 	genJwtCmd.Flags().StringSliceP("claims", "c", nil, `The list of claims to be added in the JWT. Defaults to all-access claims.
 You can specify the flag multiple times or separate the claims with a comma.`)
 	genJwtCmd.Flags().Int64P("expiry", "e", 28800, "Expiration time of the token in seconds. Defaults to 8h. 0 means the token will never expire.")
@@ -155,15 +147,6 @@ func genKeypairF(command *cobra.Command, args []string) error {
 	savePublicPEMKey(realm+"_public.pem", publicKey)
 
 	return nil
-}
-
-func validJwtType(t string) bool {
-	for _, validType := range jwtTypes {
-		if t == validType {
-			return true
-		}
-	}
-	return false
 }
 
 func genJwtF(command *cobra.Command, args []string) error {

--- a/config/base.go
+++ b/config/base.go
@@ -15,7 +15,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 
 	"gopkg.in/yaml.v2"
@@ -58,5 +58,5 @@ func SaveBaseConfiguration(configDir string, configuration BaseConfigFile) error
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path.Join(configDir, baseConfigName+".yaml"), contents, 0644)
+	return os.WriteFile(path.Join(configDir, baseConfigName+".yaml"), contents, 0644)
 }

--- a/config/cluster.go
+++ b/config/cluster.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -92,7 +91,7 @@ func SaveClusterConfiguration(configDir, clusterName string, configuration Clust
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(configPath, contents, 0644)
+	return os.WriteFile(configPath, contents, 0644)
 }
 
 // DeleteClusterConfiguration deletes a cluster configuration in the config directory. It will return

--- a/config/context.go
+++ b/config/context.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -75,7 +74,7 @@ func SaveContextConfiguration(configDir, contextName string, configuration Conte
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(configPath, contents, 0644)
+	return os.WriteFile(configPath, contents, 0644)
 }
 
 // DeleteContextConfiguration deletes a context configuration in the config directory. It will return

--- a/config/utils.go
+++ b/config/utils.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -162,7 +161,7 @@ func loadYamlFile(dirName, fileName string) ([]byte, error) {
 	}
 
 	// Read file contents and return it
-	return ioutil.ReadFile(yamlFileName)
+	return os.ReadFile(yamlFileName)
 }
 
 func ensureConfigDirectoryStructure(configDir string) error {

--- a/utils/cmdline.go
+++ b/utils/cmdline.go
@@ -49,7 +49,7 @@ func PromptChoice(question string, defaultValue string, allowEmpty, nonInteracti
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf(question)
+		fmt.Print(question)
 		if defaultValue != "" {
 			fmt.Printf(" [%s]", defaultValue)
 		}

--- a/utils/yaml_json.go
+++ b/utils/yaml_json.go
@@ -13,6 +13,9 @@ func UnmarshalYAMLToJSON(content []byte) (map[string]interface{}, error) {
 		return nil, err
 	}
 	var jsonStruct map[string]interface{}
-	json.Unmarshal(j2, &jsonStruct)
+	err = json.Unmarshal(j2, &jsonStruct)
+	if err != nil {
+		return nil, err
+	}
 	return jsonStruct, nil
 }


### PR DESCRIPTION
Add a static code check workflow that leverages golangci-lint.
Contextually, tackle all the warnings raised by the linter and remove unused code.