### PR TITLE
Build workflow: save build artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,11 @@ jobs:
 
     - name: Test
       run: go test -v -race ./...
+
+    # Load artifacts obtained with the most recent version of Go
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      if: matrix.go == '1.20.x'
+      with:
+        path: astartectl*
+        name: astartectl-snapshot-${{ matrix.os }}


### PR DESCRIPTION
Upload the build artifacts leveraging the upload-artifacts action. Artifacts are retained for 90 days.
Artifacts can be thus find in the action summary page.