### PR TITLE
Fix appengine send-data for binaryblob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `realm-management interfaces {install,upgrade}` commands are run synchronously.
 - Use Go 1.20 for releases.
 
+### Fixed
+- `appengine send-data`: fix the encoding of binaryblob and binaryblobarray data.
+
 ## [22.11.02] - 23/05/2023
 ### Changed
 - `appengine device`: print a parametric command rather than a partial one with

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.91.0
+	github.com/astarte-platform/astarte-go v0.91.1-0.20230718084224-d5bbb47f5179
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.91.0 h1:VEsTKfyEDxFzKOQLcgS9HHPiiC0p5eMkj+luSiQ3AwE=
-github.com/astarte-platform/astarte-go v0.91.0/go.mod h1:6e/IkwjAS7fXdCerA/xr/Fcv6OseNRhDFytuhCGfjvM=
+github.com/astarte-platform/astarte-go v0.91.1-0.20230718084224-d5bbb47f5179 h1:/RJX27SPJ7XmfGAp1RhNSFtuMYjBKyqTk/LDZpbdLUQ=
+github.com/astarte-platform/astarte-go v0.91.1-0.20230718084224-d5bbb47f5179/go.mod h1:XZUDeZxSGG9Z1bQJm/x5B58S7Azhu2mAdVaZV+XrEK0=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Handle the sending of binaryblob and binaryblob arrays.
Data which are modeled as binaryblob are received as strings from the command line. Then, cast the payload to bytes prior to posting it to appengine.