### PR TITLE
cluster instance deploy: allow burst instances for Astarte >= v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [22.11.04] - Unreleased
+### Fixed
+- `cluster instance deploy`: Allow real burst instances to be deployed for Astarte >= `v1.1.0`.
+
 ## [22.11.03] - 2023-07-27
 ### Added
 - `cluster instance deploy`: Allow to deploy Astarte >= `v1.1.0`.

--- a/cmd/cluster/deployment/burst_1.1.go
+++ b/cmd/cluster/deployment/burst_1.1.go
@@ -34,11 +34,7 @@ func init() {
 	astarteBurstProfile11.Compatibility.MaxAstarteVersion, _ = semver.NewVersion("1.1.99")
 	astarteBurstProfile11.Compatibility.MinAstarteVersion, _ = semver.NewVersion("1.1.0")
 
-	// Let components burst only
-	astarteBurstProfile11.DefaultSpec.Components.Resources.Requests.CPU = "0m"
-	astarteBurstProfile11.DefaultSpec.Components.Resources.Requests.Memory = "2048M"
-	astarteBurstProfile11.DefaultSpec.Components.Resources.Limits.CPU = "0m"
-	astarteBurstProfile11.DefaultSpec.Components.Resources.Limits.Memory = "3072M"
+	// Do not set resources, this will let components burst
 
 	// Queue size to a minimum, decent amount
 	astarteBurstProfile11.DefaultSpec.Components.DataUpdaterPlant.DataQueueCount = 128


### PR DESCRIPTION
The Astarte K8s Operator allows true burst instances only if no resources are specified.
Modify accordingly the burst profile for Astarte 1.1.