### PR TITLE
Fix nil pointer on device get-samples and payload parsing on device send-data 

### DIFF
--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -808,6 +808,7 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				fmt.Fprintf(os.Stderr, "You need to specify a valid path for interface %s\n", interfaceName)
 				os.Exit(1)
 			default:
+
 				if err := interfaces.ValidateQuery(interfaceDescription, interfacePath); err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
@@ -863,7 +864,12 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				// and start appending values
 				for _, v := range page {
 					if outputType != "json" {
-						t.AppendRow([]interface{}{timestampForOutput(v.Timestamp, outputType), v.Value})
+						if v.Value != nil {
+							t.AppendRow([]interface{}{timestampForOutput(v.Timestamp, outputType), v.Value})
+						} else {
+							t.AppendRow([]interface{}{timestampForOutput(v.Timestamp, outputType), []string{}})
+						}
+
 					} else {
 						sliceAcc = append(sliceAcc, v)
 					}
@@ -880,9 +886,15 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				t.AppendHeader(table.Row{"Path", "Timestamp", "Value"})
 
 				// and start appending values
+
 				for k, v := range page {
 					if outputType != "json" {
-						t.AppendRow([]interface{}{k, timestampForOutput(v.Timestamp, outputType), v.Value})
+						if v.Value != nil {
+							t.AppendRow([]interface{}{k, timestampForOutput(v.Timestamp, outputType), v.Value})
+						} else {
+							t.AppendRow([]interface{}{k, timestampForOutput(v.Timestamp, outputType), []string{}})
+						}
+
 					} else {
 						mapAcc[k] = v
 					}

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -808,7 +808,6 @@ func devicesGetSamplesF(command *cobra.Command, args []string) error {
 				fmt.Fprintf(os.Stderr, "You need to specify a valid path for interface %s\n", interfaceName)
 				os.Exit(1)
 			default:
-
 				if err := interfaces.ValidateQuery(interfaceDescription, interfacePath); err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					os.Exit(1)
@@ -1187,7 +1186,6 @@ func devicesSendDataF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	_, _ = sendDataRes.Parse()
-
 	// Done
 	fmt.Println("ok")
 	return nil
@@ -1346,10 +1344,18 @@ func parseSendDataPayload(payload string, mappingType interfaces.AstarteMappingT
 		}
 	case interfaces.BinaryBlobArray, interfaces.BooleanArray, interfaces.DateTimeArray, interfaces.DoubleArray,
 		interfaces.IntegerArray, interfaces.LongIntegerArray, interfaces.StringArray:
-		var jsonOut []interface{}
-		if err := json.Unmarshal([]byte(payload), &jsonOut); err != nil {
-			return nil, err
+
+		//wait it's all string?
+		payload = strings.Replace(payload, "[", "", -1)
+		payload = strings.Replace(payload, "]", "", -1)
+		payload_parsed := strings.Split(payload, ",")
+		//always has been
+
+		jsonOut := make([]interface{}, len(payload_parsed))
+		for i, v := range payload_parsed {
+			jsonOut[i] = v
 		}
+
 		retArray := []interface{}{}
 		// Do a smarter conversion here.
 		for _, v := range jsonOut {


### PR DESCRIPTION
Fix of nil pointer error when running command device get-samples
Fix of payload parsing when sending an array through device send-data
 