### PR TITLE
send data: do not fail on longintegers and longintegerarrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Backport deprecation of `appengine device send-data`, use
   `{publish-datastream, set-property, unset-property}` instead.
 
+### Fixed
+- `appengine send-data`: fix the encoding of longinteger and longintegerarray data.
+
 ## [23.5.0] - 2023-10-04
 ### Added
 - Add fish shell completions generator command

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.92.0
+	github.com/astarte-platform/astarte-go v0.92.1-0.20240405095359-2af3738f0d84
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.92.0 h1:Hqc7jP0U2R0lOiucRVFNICwujoDvKXM+rUaZ4F6hhCI=
-github.com/astarte-platform/astarte-go v0.92.0/go.mod h1:aqj7jyaLAkrZQ+LR0Hjc9l+n+iqSabxtwbE5IYQa0r4=
+github.com/astarte-platform/astarte-go v0.92.1-0.20240405095359-2af3738f0d84 h1:E6l76r5aVFdXe5y0Oe0WxriXFletTz+RPVTiZlci1aQ=
+github.com/astarte-platform/astarte-go v0.92.1-0.20240405095359-2af3738f0d84/go.mod h1:JY2jLeZoUP9o8+IZSIR595FgdjBj1vdYv4KuJ+tmq1U=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
Simply, update astarte-go (see https://github.com/astarte-platform/astarte-go/pull/63)