### PR TITLE
chore: update go to 1.22

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,4 +29,4 @@ jobs:
     # Run golint-ci
     - uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.53
+        version: v1.57

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2023 SECO Mind Srl
+# Copyright © 2023-2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ jobs:
     # Since v3, golangci-lint needs explicit go-setup
     - uses: actions/setup-go@v4
       with:
-        go-version: v1.20.x
+        go-version: v1.22.x
     # Run golint-ci
     - uses: golangci/golangci-lint-action@v3
       with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,10 +14,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up Go 1.20
+    - name: Set up Go 1.22
       uses: actions/setup-go@v4
       with:
-        go-version: 1.20.x
+        go-version: 1.22.x
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        go: [1.19.x, 1.20.x]
+        go: [1.21.x, 1.22.x]
         os: [ubuntu-22.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,7 +43,7 @@ jobs:
     # Load artifacts obtained with the most recent version of Go
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
-      if: matrix.go == '1.20.x'
+      if: matrix.go == '1.22.x'
       with:
         path: astartectl*
         name: astartectl-snapshot-${{ matrix.os }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.5
+golang 1.22.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Use Go 1.22 for releases.
+
 ## [23.5.1] - 2024-04-05
 ### Added
 - Backport addition of `realm-management interfaces {sync, save}` to batch

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/astarte-platform/astartectl
 
-go 1.20
+go 1.22
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5


### PR DESCRIPTION
update to the latest version of go.

golangci-lint also needs to be updated for go 1.22.