### PR TITLE
`realm-management {interfaces | triggers} sync`: do not display a wrong curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [23.5.2] - Unreleased
+### Fixed
+- `realm-management {interfaces, triggers} sync`: do not show a wrong curl
+  command when using `--to-curl`. Reference individual commands instead.
+
 ## [23.5.1] - 2024-04-05
 ### Added
 - Backport addition of `realm-management interfaces {sync, save}` to batch

--- a/cmd/realm/interfaces.go
+++ b/cmd/realm/interfaces.go
@@ -249,7 +249,7 @@ func interfacesUpdateF(command *cobra.Command, args []string) error {
 
 func interfacesSyncF(command *cobra.Command, args []string) error {
 	// `interface sync` is unnatural btw
-	if viper.GetBool("to-curl") {
+	if viper.GetBool("realmmanagement-to-curl") {
 		fmt.Println(`'interfaces sync' does not support the --to-curl option.
 Install or update your interfaces one by one with 'interfaces install' or 'interface update'.`)
 		os.Exit(1)

--- a/cmd/realm/triggers.go
+++ b/cmd/realm/triggers.go
@@ -220,7 +220,7 @@ func triggersSaveF(command *cobra.Command, args []string) error {
 }
 
 func triggersSyncF(command *cobra.Command, args []string) error {
-	if viper.GetBool("to-curl") {
+	if viper.GetBool("realmmanagement-to-curl") {
 		fmt.Println(`'triggers sync' does not support the --to-curl option. Install your triggers one by one with 'triggers install'.`)
 		os.Exit(1)
 	}

--- a/go.sum
+++ b/go.sum
@@ -537,7 +537,6 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
-github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Do not display an equivalent curl for syncing interfaces and triggers, as no single command can do the same.
Rather, point to the individual commands (`install`, `update`, `delete`).

Also, fix a leftover line in `go.mod`.