### PR TITLE
Correctly send empty array to astarte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `cluster instance` {`deploy` | `destroy` | `show`} are deprecated and
   will be removed from v24.11.
 ### Fixed
-- Create configuration files and folders if required, instead of just crashing
+- Create configuration files and folders if required, instead of just crashing.
+- Fixed empty array sent as empty string for array payload.
 
 ## [24.5.0] - 2024-09-03
 ### Added


### PR DESCRIPTION
Fix send of empty array to astarte, that defaulted to empty string that was obviously not the correct payload.
Now it is sent as an empty array. 
Please note that an empty array differs from an array with one element of value "empty" or zero, that's why i did not edit the existent parser solution but added another one instead