### PR TITLE
Add exceptions for aggregate payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - `realm-management {interfaces, triggers} sync`: do not show a wrong curl
   command when using `--to-curl`. Reference individual commands instead.
+- `appengine publish-datastream`: fix the decoding of longinteger
+  and longintegerarray before sending to astarte.
 
 ## [23.5.1] - 2024-04-05
 ### Added

--- a/cmd/appengine/device.go
+++ b/cmd/appengine/device.go
@@ -1276,6 +1276,21 @@ func devicesPublishDataStreamF(command *cobra.Command, args []string) error {
 					}
 					aggrPayload[k] = acc
 				}
+				if payloadType == interfaces.IntegerArray {
+					acc := make([]int32, 0)
+
+					for _, item := range val {
+						acc = append(acc, int32(item.(float64)))
+					}
+					aggrPayload[k] = acc
+				}
+				if payloadType == interfaces.LongIntegerArray {
+					acc := make([]int64, 0)
+					for _, item := range val {
+						acc = append(acc, int64(item.(float64)))
+					}
+					aggrPayload[k] = acc
+				}
 			}
 		}
 		parsedPayloadData = aggrPayload


### PR DESCRIPTION
Add exceptions for aggregate payloads of type longintegerarray and integerarray when sending data to astarte. It is now correctly parsed before sending instead of being treated like interface arrays