### PR TITLE
CI: add goreleaser check action

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -1,0 +1,32 @@
+name: Release Check
+on:
+  # Run on mainline branches
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on Pull Requests
+  pull_request:
+
+jobs:
+  goreleaser-check:
+    name: goreleaser-check
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Go 1.21
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21.x
+    - name: Run GoReleaser Check
+      uses: goreleaser/goreleaser-action@v4
+      with:
+        distribution: goreleaser
+        version: v2
+        args: check
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ nfpms:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 release:
   prerelease: auto
   name_template: "astartectl {{.Version}}"
@@ -76,4 +76,4 @@ release:
   draft: true
 changelog:
   # We have our own way to track changes
-  skip: true
+  disable: true


### PR DESCRIPTION
We don't want to find out a release will fail after a tag has been made. Thus, ensure the release action run smooth and we can rely on goreleaser when needed.