### PR TITLE
`cluster instance`: deprecate `destroy`, `install` and `show` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [24.5.1] - Unreleased
+### Changed
+- `cluster instance` {`deploy` | `destroy` | `show`} are deprecated and
+  will be removed from v24.11.
+
 ## [24.5.0] - 2024-09-03
 ### Added
 - `cluster instance deploy`: add profiles for astarte v1.2.

--- a/cmd/cluster/instance_deploy.go
+++ b/cmd/cluster/instance_deploy.go
@@ -37,6 +37,9 @@ var deployCmd = &cobra.Command{
 kubectl mentions. If no versions are specified, the last stable version is deployed. This should only be used for testing purposes.`,
 	Example: `  astartectl cluster instances deploy`,
 	RunE:    clusterDeployF,
+	Deprecated: `This command is deprecated and will be removed in future releases.
+Refer to the Astarte documentation on how to install Astarte on your cluster:
+https://docs.astarte-platform.org/astarte-kubernetes-operator/latest`,
 }
 
 func init() {

--- a/cmd/cluster/instance_destroy.go
+++ b/cmd/cluster/instance_destroy.go
@@ -33,6 +33,9 @@ kubectl mentions. Please be aware of the fact that when an Astarte instance is d
 	Example: `  astartectl cluster instances destroy astarte`,
 	RunE:    clusterDestroyF,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: `This command is deprecated and will be removed in future releases.
+Refer to the Astarte documentation on how to remove Astarte from your cluster:
+https://docs.astarte-platform.org/astarte-kubernetes-operator/latest`,
 }
 
 func init() {

--- a/cmd/cluster/instance_show.go
+++ b/cmd/cluster/instance_show.go
@@ -29,6 +29,9 @@ var instanceShowCmd = &cobra.Command{
 	Example: `  astartectl cluster instances show astarte`,
 	RunE:    instanceShowF,
 	Args:    cobra.ExactArgs(1),
+	Deprecated: `This command is deprecated and will be removed in future releases.
+Refer to the Astarte documentation on how to interact with Astarte:
+https://docs.astarte-platform.org/astarte-kubernetes-operator/latest`,
 }
 
 func init() {


### PR DESCRIPTION
astartectl is an Astarte client, not a k8s one. Let kubectl handle the interaction with k8s API to install/retrieve/destroy an instance.
The commands are deprecated and will be removed starting from v24.11.