### PR TITLE
`appengine device {aliases | attribues} list`: show a human-readable map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [24.5.3] - Unreleased
+### Fixed
+- `appengine device alias list`: show aliases as a map instead of a list.
+  Fix [#275](https://github.com/astarte-platform/astartectl/issues/275).
+
 ## [24.5.2] - 2024-09-20
 ### Fixed
 - Allow a larger set of permissions for configuration files and folders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [24.5.3] - Unreleased
+### Changed
+- `appengine device attributes list`: display attributes in a human-friendly
+  representation instead Go's internal one. Keep consistency with aliases.
+
 ### Fixed
 - `appengine device alias list`: show aliases as a map instead of a list.
   Fix [#275](https://github.com/astarte-platform/astartectl/issues/275).

--- a/cmd/appengine/device_aliases.go
+++ b/cmd/appengine/device_aliases.go
@@ -92,8 +92,12 @@ func aliasesListF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	aliases, _ := deviceAliasesRes.Parse()
+	aliasesMap, _ := aliases.(map[string]string)
 
-	fmt.Printf("%v\n", aliases)
+	for k, v := range aliasesMap {
+		fmt.Printf("%v: %v\n", k, v)
+	}
+
 	return nil
 }
 

--- a/cmd/appengine/device_attributes.go
+++ b/cmd/appengine/device_attributes.go
@@ -111,8 +111,12 @@ func attributesListF(command *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 	attributes, _ := attributesRes.Parse()
+	attributesMap, _ := attributes.(map[string]string)
 
-	fmt.Printf("%v\n", attributes)
+	for k, v := range attributesMap {
+		fmt.Printf("%v: %v\n", k, v)
+	}
+
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20211005130812-5bb3c17173e5
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
-	github.com/astarte-platform/astarte-go v0.92.1
+	github.com/astarte-platform/astarte-go v0.92.2-0.20241112115810-b8a1c0732cf1
 	github.com/go-openapi/strfmt v0.21.1 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/go-github/v30 v30.1.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/astarte-platform/astarte-go v0.92.1 h1:9zUiw1E4uj2wBDeszxGh/IAnVFg7BDKhRWqioksG0WA=
-github.com/astarte-platform/astarte-go v0.92.1/go.mod h1:JY2jLeZoUP9o8+IZSIR595FgdjBj1vdYv4KuJ+tmq1U=
+github.com/astarte-platform/astarte-go v0.92.2-0.20241112115810-b8a1c0732cf1 h1:E+mIQLxInwu5VwMjrmPvqB4bqJFBw2SUHzGkr/aZ9oI=
+github.com/astarte-platform/astarte-go v0.92.2-0.20241112115810-b8a1c0732cf1/go.mod h1:JY2jLeZoUP9o8+IZSIR595FgdjBj1vdYv4KuJ+tmq1U=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
- Astarte Device aliases are a map. Print them as so, instead of an empty list. This follows a fix in astarte-go (see https://github.com/astarte-platform/astarte-go/pull/68), so the dependency is updated contextually.  
- In order to keep consistency, display the same output format also for attributes.

Now, aliases and attributes are displayed like this:
```
foo: bar
baz: foo
```


Fixes #275