### PR TITLE
Refactor `astartectl utils validate`  interfaces, triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Allow a larger set of permissions for configuration files and folders.
 
+### Added
+- Add validation confirmation messages for Astarte Interface and Trigger in the utils package for improved user feedback.
+
 ## [24.5.1] - 2024-09-19
 ### Changed
 - `cluster instance` {`deploy` | `destroy` | `show`} are deprecated and

--- a/cmd/utils/interfaces.go
+++ b/cmd/utils/interfaces.go
@@ -35,7 +35,7 @@ var validateInterfaceCmd = &cobra.Command{
 Note that the checks performed by this function are not as thorough as the ones performed by Astarte, so there could be false positives (but no false negatives).
 This command is thought to be used in CI pipelines to validate that new interfaces are "reasonable enough".
 
-Returns 0 and does not print anything if the interface is valid, returns 1 and prints an error message if it isn't.`,
+Returns 0 and print message if the interface is valid, returns 1 and prints an error message if it isn't.`,
 	Example: `  astartectl utils interfaces validate com.my.Interface.json`,
 	Args:    cobra.ExactArgs(1),
 	RunE:    validateInterfaceF,
@@ -56,6 +56,8 @@ func validateInterfaceF(command *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Interface: %s\n", interfacePath, err)
 		os.Exit(1)
 	}
+
+	fmt.Printf("%s is a valid Astarte Interface\n", interfacePath)
 
 	return nil
 }

--- a/cmd/utils/triggers.go
+++ b/cmd/utils/triggers.go
@@ -35,7 +35,7 @@ var validateTriggerCmd = &cobra.Command{
 Note that the checks performed by this function are not as thorough as the ones performed by Astarte, so there could be false positives (but no false negatives).
 This command is thought to be used in CI pipelines to validate that new triggers are "reasonable enough".
 
-Returns 0 and does not print anything if the trigger is valid, returns 1 and prints an error message if it isn't.`,
+Returns 0 and print message if the trigger is valid, returns 1 and prints an error message if it isn't.`,
 	Example: `  astartectl utils triggers validate my_trigger.json`,
 	Args:    cobra.ExactArgs(1),
 	RunE:    validateTriggerF,
@@ -56,6 +56,8 @@ func validateTriggerF(command *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "%s is not a valid Astarte Trigger: %s\n", triggerPath, err)
 		os.Exit(1)
 	}
+
+	fmt.Printf("%s is a valid Astarte Trigger\n", triggerPath)
 
 	return nil
 }


### PR DESCRIPTION
`cmd/utils` package to improve user feedback during validation processes. The most important changes are the addition of print statements to confirm the validity of interfaces and triggers.

Improvements to user feedback:

* [`cmd/utils/interfaces.go`](diffhunk://#diff-4f718e9c7752646656f1e9975c4c51c1c4c66b705f5143f8728509655c58591bR60-R61): Added a print statement to confirm when an interface is valid.
* [`cmd/utils/triggers.go`](diffhunk://#diff-01f07161bf602bc26318a8ce263cc5d7beb79f050b62915ad8f8ee8124a7d21fR60-R61): Added a print statement to confirm when a trigger is valid.Add validation confirmation messages for Astarte Interface and Trigger